### PR TITLE
Fix a encoding problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ rcasm.json
 rcblocks.json
 rcinterface.json
 rcstyle.json
+
+# IntelliJ IDEA Project stuff
+.idea/
+out/
+*.iws
+*.iml
+*___jb_*___

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,9 @@
 	<version>0.9</version>
 	<name>Recaf</name>
 	<description>A modern java bytecode editor</description>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<repositories>
 		<!-- 
 		Local repository.

--- a/src/me/coley/recaf/util/Streams.java
+++ b/src/me/coley/recaf/util/Streams.java
@@ -3,7 +3,7 @@ package me.coley.recaf.util;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -40,7 +40,7 @@ public class Streams {
 	}
 	
     public static String toString(final InputStream input) throws IOException {
-        return new String(from(input), Charset.defaultCharset());
+        return new String(from(input), StandardCharsets.UTF_8);
     }
 
 	/**


### PR DESCRIPTION
`Charset.defaultCharset()` will return different charsets on different platforms. For example, this method returns `GBK` in China, which will result in some unintelligible texts like this:
![Recaf with Chinese language file](https://user-images.githubusercontent.com/12008103/35724728-c5fbf16c-0839-11e8-9fbe-31bb5d7eb8ec.jpg)

I hope my expression are understandable, I'm not native speakers.