### PR TITLE
NPE for member fields

### DIFF
--- a/src/me/coley/recaf/ui/component/ReflectiveFieldNodeItem.java
+++ b/src/me/coley/recaf/ui/component/ReflectiveFieldNodeItem.java
@@ -159,7 +159,7 @@ public class ReflectiveFieldNodeItem extends ReflectiveClassNodeItem {
 			FieldNode field = (FieldNode) item.getOwner();
 			Class<?> valueClass = Misc.getTypeClass(field.desc);
 			PropertyEditor<T> editor = null;
-			if (valueClass.equals(String.class)) {
+			if (String.class.equals(valueClass)) {
 				editor = (PropertyEditor<T>) Editors.createTextEditor(item);
 			} else if (Misc.isNumeric(valueClass)) {
 				editor = (PropertyEditor<T>) Editors.createNumericEditor(item);
@@ -168,7 +168,9 @@ public class ReflectiveFieldNodeItem extends ReflectiveClassNodeItem {
 				// defaultValue's for other types
 				return FormatFactory.name("Unknown type: " + valueClass.getName());
 			}
-			editor.setValue(getValue());
+			T value = getValue();
+			if(value!=null)
+				editor.setValue(value);
 			return editor.getEditor();
 		}
 	}


### PR DESCRIPTION
While modifying class member attributes I got a NPE since there is no current value  (in contrast to static fields). The NPE was silently dropped and the dialog won't open. 
Thus I just skipped the editor.setValue().

The swap in line 162 is not a bug but just a suggestion of my Intellij to avoid further NPE's if valueClass becomes NULL for some reason. (although I just see this must possibly be considered at line 169, too)