### PR TITLE
Fix a small bug in annotation formatting

### DIFF
--- a/src/me/coley/recaf/ui/FormatFactory.java
+++ b/src/me/coley/recaf/ui/FormatFactory.java
@@ -125,7 +125,7 @@ public class FormatFactory {
 		int max = item.values == null ? 0 : item.values.size();
 		if (max > 0) {
 			addRaw(t, "(");
-			for (int i = 0, n = max; i < n; i += 2) {
+			for (int i = 0; i < max; i += 2) {
 				String name = (String) item.values.get(i);
 				Object value = item.values.get(i + 1);
 				addName(t, name);
@@ -148,7 +148,7 @@ public class FormatFactory {
 					Logging.warn("Unknown annotation data: @" + i + " type: " + value.getClass());
 					addRaw(t, value.toString());
 				}
-				if (i + 1 < max) {
+				if (i + 2 < max) {
 					addRaw(t, ", ");
 				}
 			}


### PR DESCRIPTION
### Before
![annotation-format-actual](https://user-images.githubusercontent.com/12008103/46195719-a72a8780-c337-11e8-9f77-80fa1c1741b2.png)

### After
![annotation-format-expected](https://user-images.githubusercontent.com/12008103/46195727-ac87d200-c337-11e8-92e2-0a82c1460ff8.png)

### Steps to reproduce
1. Open any jar.
2. Navigate to any member with a non-marker annotation. (I used `recaf.jar!/Input.onNewInput()`)
3. Double click on them.
4. Click `Visible/Invisible (type) annotations` button.