### PR TITLE
Always load default language

### DIFF
--- a/src/me/coley/recaf/config/impl/ConfDisplay.java
+++ b/src/me/coley/recaf/config/impl/ConfDisplay.java
@@ -6,6 +6,7 @@ import com.eclipsesource.json.JsonValue;
 import me.coley.logging.Level;
 import me.coley.recaf.config.Conf;
 import me.coley.recaf.config.Config;
+import me.coley.recaf.util.Lang;
 
 /**
  * Options for user-interface.
@@ -37,7 +38,7 @@ public class ConfDisplay extends Config {
 	 * UI language.
 	 */
 	@Conf(category = "display", key = "language")
-	public String language = "en";
+	public String language = Lang.DEFAULT_LANGUAGE;
 	/**
 	 * Stylesheet group to use. 
 	 */

--- a/src/me/coley/recaf/util/Lang.java
+++ b/src/me/coley/recaf/util/Lang.java
@@ -15,6 +15,7 @@ import me.coley.recaf.config.impl.ConfDisplay;
  * @author Matt
  */
 public class Lang {
+	public static final String DEFAULT_LANGUAGE = "en";
 	private static final Map<String, String> map = new HashMap<>();
 	private final static boolean DEBUG = true;
 
@@ -48,9 +49,7 @@ public class Lang {
 			// FxWindow.logging.fine("Loading language from: " + file, 1);
 			String jsStr = Streams.toString(Lang.class.getResourceAsStream(file));
 			JsonObject json = Json.parse(jsStr).asObject();
-			json.forEach(v -> {
-				map.put(v.getName(), v.getValue().asString());
-			});
+			json.forEach(v -> map.put(v.getName(), v.getValue().asString()));
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
@@ -69,6 +68,7 @@ public class Lang {
 	}
 
 	static {
+		load(DEFAULT_LANGUAGE);
 		load(ConfDisplay.instance().language);
 	}
 }


### PR DESCRIPTION
So if the chosen translation is outdated, it can fallback gracefully to English instead of showing error messages.