### PR TITLE
Scan boot classpath on JVM 9 and later

### DIFF
--- a/src/main/java/me/coley/recaf/util/Classpath.java
+++ b/src/main/java/me/coley/recaf/util/Classpath.java
@@ -137,7 +137,7 @@ public class Classpath {
 			// auto-completion will not able to suggest internal names of any of the classes under java.*,
 			// which will largely reduce the effectiveness of the feature.
 			if (!checkBootstrapClass()) {
-				int vmVersion = Integer.parseInt(System.getProperty("java.class.version")) - 44;
+				float vmVersion = Float.parseFloat(System.getProperty("java.class.version")) - 44;
 				if (vmVersion < 9) {
 					try {
 						Method method = ClassLoader.class.getDeclaredMethod("getBootstrapClassPath");
@@ -161,6 +161,7 @@ public class Classpath {
 						Object bootstrapClasspath = field.get(bootLoader);
 						scanBootstrapClasspath(field, classLoader, bootstrapClasspath);
 					} catch (ReflectiveOperationException | SecurityException e) {
+						e.printStackTrace();
 						throw new ExceptionInInitializerError(e);
 					}
 				}

--- a/src/main/java/me/coley/recaf/util/Classpath.java
+++ b/src/main/java/me/coley/recaf/util/Classpath.java
@@ -161,7 +161,6 @@ public class Classpath {
 						Object bootstrapClasspath = field.get(bootLoader);
 						scanBootstrapClasspath(field, classLoader, bootstrapClasspath);
 					} catch (ReflectiveOperationException | SecurityException e) {
-						e.printStackTrace();
 						throw new ExceptionInInitializerError(e);
 					}
 				}

--- a/src/main/java/me/coley/recaf/util/Classpath.java
+++ b/src/main/java/me/coley/recaf/util/Classpath.java
@@ -156,6 +156,7 @@ public class Classpath {
 
 						Object bootstrapClasspath = method.invoke(null);
 						scanBootstrapClasspath(field, classLoader, bootstrapClasspath);
+						verifyScan();
 					} catch (ReflectiveOperationException | SecurityException e) {
 						throw new ExceptionInInitializerError(e);
 					}
@@ -246,6 +247,8 @@ public class Classpath {
 							// Manually add everything, can't use Guava here
 							closeReader.invoke(reader);
 						}
+
+						verifyScan();
 					} catch (Throwable t) {
 						throw new ExceptionInInitializerError(t);
 					}
@@ -260,6 +263,12 @@ public class Classpath {
 			((ArrayList<String>) internalNames).trimToSize();
 		}
 
+		private void verifyScan() {
+			if (!checkBootstrapClass()) {
+				Logging.warn("Bootstrap classes are (still) missing from the classpath scan!");
+			}
+		}
+
 		private void scanBootstrapClasspath(Field field, ClassLoader classLoader, Object bootstrapClasspath) throws IllegalAccessException, NoSuchFieldException {
 			URLClassLoader dummyLoader = new URLClassLoader(new URL[0], classLoader);
 			field.setAccessible(true);
@@ -272,10 +281,6 @@ public class Classpath {
 			field.set(dummyLoader, bootstrapClasspath);
 			// And then feed it into Guava's ClassPath scanner.
 			updateClassPath(dummyLoader);
-
-			if (!checkBootstrapClass()) {
-				Logging.warn("Bootstrap classes are (still) missing from the classpath scan!");
-			}
 		}
 	}
 }

--- a/src/main/java/me/coley/recaf/util/Classpath.java
+++ b/src/main/java/me/coley/recaf/util/Classpath.java
@@ -215,7 +215,8 @@ public class Classpath {
 						field.setAccessible(true);
 
 						Object bootstrapClasspath = field.get(bootLoader);
-						scanBootstrapClasspath(URLClassLoader.class.getDeclaredField("ucp"), classLoader, bootstrapClasspath);
+						if (bootstrapClasspath != null)
+							scanBootstrapClasspath(URLClassLoader.class.getDeclaredField("ucp"), classLoader, bootstrapClasspath);
 					} catch (Throwable t) {
 						throw new ExceptionInInitializerError(t);
 					}
@@ -232,6 +233,7 @@ public class Classpath {
 
 		private void scanBootstrapClasspath(Field field, ClassLoader classLoader, Object bootstrapClasspath) throws IllegalAccessException, NoSuchFieldException {
 			URLClassLoader dummyLoader = new URLClassLoader(new URL[0], classLoader);
+			field.setAccessible(true);
 			if (Modifier.isFinal(field.getModifiers())) {
 				Field modifiers = Field.class.getDeclaredField("modifiers");
 				modifiers.setAccessible(true);

--- a/src/main/java/me/coley/recaf/util/Classpath.java
+++ b/src/main/java/me/coley/recaf/util/Classpath.java
@@ -233,7 +233,7 @@ public class Classpath {
 						listReader.setAccessible(true);
 						Field bootModulesField = bootLoader.getClass().getSuperclass().getDeclaredField("packageToModule");
 						bootModulesField.setAccessible(true);
-						Collection<?> packageToModule = ((Map<String, ?>) bootModulesField.get(bootLoader)).values();
+						Collection<?> packageToModule = ((Map<String, ?>) bootModulesField.get(null)).values();
 						for (Object module : packageToModule) {
 							// Scan it!
 							Object ref = mref.invoke(module);

--- a/src/main/java/me/coley/recaf/util/Dependencies.java
+++ b/src/main/java/me/coley/recaf/util/Dependencies.java
@@ -16,7 +16,7 @@ import javax.swing.*;
  */
 public class Dependencies {
 
-	public static boolean check() {
+	public static boolean 	check() {
 		double version = getVersion();
 		if (version < 1.8) {
 			// Java 7-

--- a/src/main/java/me/coley/recaf/util/Dependencies.java
+++ b/src/main/java/me/coley/recaf/util/Dependencies.java
@@ -16,7 +16,7 @@ import javax.swing.*;
  */
 public class Dependencies {
 
-	public static boolean 	check() {
+	public static boolean check() {
 		double version = getVersion();
 		if (version < 1.8) {
 			// Java 7-


### PR DESCRIPTION
## What's new

Returns scanning of boot classpath on JVM 9 and later versions, checking of version is done by checking `java.class.version` system property