### PR TITLE
 Remove the redundant copying in overlapping results calculation

### DIFF
--- a/src/main/java/me/coley/recaf/search/ClassReferenceQuery.java
+++ b/src/main/java/me/coley/recaf/search/ClassReferenceQuery.java
@@ -1,6 +1,6 @@
 package me.coley.recaf.search;
 
-import java.util.function.Supplier;
+import java.util.function.IntSupplier;
 
 /**
  * Query to find references to the given class.
@@ -29,9 +29,9 @@ public class ClassReferenceQuery extends Query {
 	 * @param name
 	 * 		Name of class.
 	 */
-	public void match(Supplier<Integer> access, String name) {
+	public void match(IntSupplier access, String name) {
 		if (stringMode.match(this.name, name)) {
-			getMatched().add(new ClassResult(access.get(), name));
+			getMatched().add(new ClassResult(access.getAsInt(), name));
 		}
 	}
 }

--- a/src/main/java/me/coley/recaf/search/Context.java
+++ b/src/main/java/me/coley/recaf/search/Context.java
@@ -44,6 +44,14 @@ public abstract class Context<T extends Context> implements Comparable<Context<?
 	}
 
 	/**
+	 * @param other the context to be compared
+	 * @return {@code true} if both contexts are considered similar
+	 */
+	public boolean isSimilar(Context<?> other) {
+		return this == other || (this.getClass() == other.getClass() && this.compareTo(other) == 0);
+	}
+
+	/**
 	 * Class context.
 	 */
 	public static class ClassContext extends Context<Context> {
@@ -228,6 +236,11 @@ public abstract class Context<T extends Context> implements Comparable<Context<?
 			}
 			// Most deep context, so always be "less than"
 			return -1;
+		}
+
+		@Override
+		public boolean isSimilar(Context<?> other) {
+			return this == other || (this.getClass() == other.getClass() && parent.compareTo(other.parent) == 0);
 		}
 	}
 

--- a/src/main/java/me/coley/recaf/search/MemberReferenceQuery.java
+++ b/src/main/java/me/coley/recaf/search/MemberReferenceQuery.java
@@ -1,6 +1,6 @@
 package me.coley.recaf.search;
 
-import java.util.function.Supplier;
+import java.util.function.IntSupplier;
 
 /**
  * Query to find member references matching the given information.
@@ -47,12 +47,12 @@ public class MemberReferenceQuery extends Query {
 	 * @param desc
 	 * 		Member descriptor.
 	 */
-	public void match(Supplier<Integer> access, String owner, String name, String desc) {
+	public void match(IntSupplier access, String owner, String name, String desc) {
 		boolean hasOwner = this.owner == null || stringMode.match(this.owner, owner);
 		boolean hasName = this.name == null || stringMode.match(this.name, name);
 		boolean hasDesc = this.desc == null || stringMode.match(this.desc, desc);
 		if(hasOwner && hasName && hasDesc) {
-			getMatched().add(new MemberResult(access.get(), owner, name, desc));
+			getMatched().add(new MemberResult(access.getAsInt(), owner, name, desc));
 		}
 	}
 }

--- a/src/main/java/me/coley/recaf/search/SearchCollector.java
+++ b/src/main/java/me/coley/recaf/search/SearchCollector.java
@@ -2,12 +2,14 @@ package me.coley.recaf.search;
 
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.Multimaps;
 import me.coley.recaf.util.ClassUtil;
 import me.coley.recaf.workspace.Workspace;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.*;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.function.IntSupplier;
 import java.util.stream.Stream;
 
@@ -17,23 +19,20 @@ import static org.objectweb.asm.ClassReader.*;
 /**
  * Search result collector.
  *
- * <br><br>
- *
- * <b>Search API TODO List:</b>
- * <ul>
- * <li>Member references in more obscure cases</li>
- * <li>Method inheritance (child of given)</li>
- * <li>Instruction text match (depends on text disassembler being finished)</li>
- * <li>Smart optimization, skip certain visitor-api calls if we know our queries won't need to
- * look there</li>
- * </ul>
- *
  * @author Matt
+ */
+/*
+ * TODO with Search API:
+ *  - Member references in more obscure cases
+ *  - Method inheritance (child of given)
+ *  - Instruction text match (depends on text disassembler being finished)
+ *  - Smart optimization, skip certain visitor-api calls if we know our queries won't need to look there
  */
 public class SearchCollector {
 	public static final int ACC_NOT_FOUND = -1;
 	private final ListMultimap<Query, SearchResult> results = MultimapBuilder
 			.linkedHashKeys(2).arrayListValues().build();
+	private final Map<Query, List<SearchResult>> resultMapView = Multimaps.asMap(results);
 	private final Workspace workspace;
 	private final Collection<Query> queries;
 
@@ -59,44 +58,29 @@ public class SearchCollector {
 
 	/**
 	 * @return Flattened list of the {@link #getResultsMap() result map} containing entries shared
-	 * among multiple queries that share the same common contexts.
+	 * among multiple queries that are similar.
+	 * @see SearchResult#isContextSimilar(SearchResult)
 	 */
-	@SuppressWarnings("unchecked")
 	public List<SearchResult> getOverlappingResults() {
-		// Get results of multiple queries that have either the same parent context
-		// (or just same context in some cases)
-		// TODO: remove asMap() call?
-		return new ArrayList<>(results.asMap().values().stream()
+		// Get results of multiple queries that are similar
+		return resultMapView.values().stream()
+				// Cast the stream to Collection for compatibility with LinkedHashSet
+				.map((Function<List<?>, Collection<SearchResult>>) Collection.class::cast)
 				.reduce((a, b) -> {
-					// Set so we don't get duplicates
-					Set<SearchResult> ret = new LinkedHashSet<>();
-					for (SearchResult resA : a) {
-						for (SearchResult resB : b) {
-							// Contexts must be of the same type
-							if (!resA.getContext().getClass().equals(resB.getContext().getClass()))
-								continue;
-							Context<?> ctxA = resA.getContext();
-							Context<?> ctxB = resB.getContext();
-							if (ctxA instanceof Context.ClassContext ||
-									ctxA instanceof Context.AnnotationContext ||
-									ctxA instanceof Context.MemberContext) {
-								// For class, annotation, and members the contexts should match
-								if (ctxA.compareTo(ctxB) == 0) {
-									ret.add(resA);
-									ret.add(resB);
-								}
-							}  else if (ctxA instanceof Context.InsnContext) {
-								// For instructions the parent contexts should match
-								if (ctxA.getParent().compareTo(ctxB.getParent()) == 0) {
-									ret.add(resA);
-									ret.add(resB);
-								}
+					Set<SearchResult> overlapping = new LinkedHashSet<>(Math.min(a.size(), b.size()));
+					for (SearchResult resultA : a) {
+						for (SearchResult resultB : b) {
+							if (resultA.isContextSimilar(resultB)) {
+								overlapping.add(resultA);
+								overlapping.add(resultB);
 							}
 						}
 					}
-					// Back to list
-					return new ArrayList<>(ret);
-				}).get());
+					return overlapping;
+				})
+				// Cast the Optional to List for compatibility with Collections.emptyList()
+				.map((Function<Collection<SearchResult>, List<SearchResult>>) ArrayList::new)
+				.orElseGet(Collections::emptyList);
 	}
 
 	/**

--- a/src/main/java/me/coley/recaf/search/SearchCollector.java
+++ b/src/main/java/me/coley/recaf/search/SearchCollector.java
@@ -8,7 +8,7 @@ import org.objectweb.asm.*;
 import org.objectweb.asm.tree.*;
 
 import java.util.*;
-import java.util.function.Supplier;
+import java.util.function.IntSupplier;
 import java.util.stream.Stream;
 
 import static org.objectweb.asm.ClassReader.*;
@@ -140,11 +140,11 @@ public class SearchCollector {
 	// we are sure that there is a match and this information is needed.
 	// Looking this up in hundreds of cases where we don't need it would just waste time.
 
-	Supplier<Integer> getAccess(String owner, String name, String desc) {
+	IntSupplier getAccess(String owner, String name, String desc) {
 		return () -> acc(owner, name, desc, ACC_NOT_FOUND);
 	}
 
-	Supplier<Integer> getAccess(String name, int defaultAcc) {
+	IntSupplier getAccess(String name, int defaultAcc) {
 		return () -> acc(name, defaultAcc);
 	}
 

--- a/src/main/java/me/coley/recaf/search/SearchResult.java
+++ b/src/main/java/me/coley/recaf/search/SearchResult.java
@@ -29,4 +29,13 @@ public abstract class SearchResult implements Comparable<SearchResult> {
 	public int compareTo(SearchResult other) {
 		return context.compareTo(other.context);
 	}
+
+	/**
+	 * @param other the search result to be compared
+	 * @return {@code true} if both contexts are considered similar
+	 * @see Context#isSimilar(Context)
+	 */
+	public boolean isContextSimilar(SearchResult other) {
+		return context != null && other.context != null && context.isSimilar(other.context);
+	}
 }


### PR DESCRIPTION
This is related to #164.

If there was [an `Lists.concat` method in Guava](//github.com/google/guava/pull/1029), we can avoid the copying in `getAllResults()` too, but I guess not...