### PR TITLE
Fix viewports are not cleared after workspace load

### DIFF
--- a/src/main/java/me/coley/recaf/control/gui/GuiController.java
+++ b/src/main/java/me/coley/recaf/control/gui/GuiController.java
@@ -111,6 +111,7 @@ public class GuiController extends Controller {
 					}).start();
 					// Start the load process
 					setWorkspace(loader.call());
+					windows.getMainWindow().clearTabViewports();
 					configs.backend().recentFiles.add(file.getAbsolutePath());
 					return true;
 				} catch(Exception ex) {

--- a/src/main/java/me/coley/recaf/ui/MainWindow.java
+++ b/src/main/java/me/coley/recaf/ui/MainWindow.java
@@ -189,6 +189,14 @@ public class MainWindow extends Application {
 	}
 
 	/**
+	 * Clear tab viewports
+	 */
+	public void clearTabViewports() {
+		if (tabs != null)
+			tabs.clearViewports();
+	}
+
+	/**
 	 * Set disability status of window components.
 	 *
 	 * @param status

--- a/src/main/java/me/coley/recaf/ui/controls/ViewportTabs.java
+++ b/src/main/java/me/coley/recaf/ui/controls/ViewportTabs.java
@@ -58,8 +58,6 @@ public class ViewportTabs extends TabPane {
 	 * @return Viewport of the class.
 	 */
 	public ClassViewport openClass(JavaResource resource, String name) {
-		System.out.println(resource);
-		System.out.println(nameToTab.containsKey(name));
 		if(nameToTab.containsKey(name))
 			return getClassViewport(name);
 		ClassViewport view = new ClassViewport(controller, resource, name);

--- a/src/main/java/me/coley/recaf/ui/controls/ViewportTabs.java
+++ b/src/main/java/me/coley/recaf/ui/controls/ViewportTabs.java
@@ -58,6 +58,8 @@ public class ViewportTabs extends TabPane {
 	 * @return Viewport of the class.
 	 */
 	public ClassViewport openClass(JavaResource resource, String name) {
+		System.out.println(resource);
+		System.out.println(nameToTab.containsKey(name));
 		if(nameToTab.containsKey(name))
 			return getClassViewport(name);
 		ClassViewport view = new ClassViewport(controller, resource, name);
@@ -121,6 +123,13 @@ public class ViewportTabs extends TabPane {
 			return (FileViewport) tab.getContent();
 		}
 		return null;
+	}
+
+	/**
+	 * Clears viewports
+	 */
+	public void clearViewports() {
+		nameToTab.clear();
 	}
 
 	private Tab createTab(String name, EditorViewport view) {


### PR DESCRIPTION
Fixes a bug when a class with the same name cannot be opened again.
