### PR TITLE
fix: NPE if the workspace not initialized

### DIFF
--- a/src/main/java/me/coley/recaf/ui/MainMenu.java
+++ b/src/main/java/me/coley/recaf/ui/MainMenu.java
@@ -1,7 +1,9 @@
 package me.coley.recaf.ui;
 
 import javafx.scene.Node;
-import javafx.scene.control.*;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.SeparatorMenuItem;
 import javafx.stage.FileChooser;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Stage;
@@ -21,7 +23,7 @@ import me.coley.recaf.util.self.SelfUpdater;
 import me.coley.recaf.workspace.*;
 import org.apache.commons.io.FileUtils;
 
-import java.awt.Desktop;
+import java.awt.*;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -30,10 +32,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import static me.coley.recaf.util.LangUtil.translate;
-import static me.coley.recaf.util.Log.*;
-import static me.coley.recaf.util.UiUtil.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static me.coley.recaf.util.LangUtil.translate;
+import static me.coley.recaf.util.Log.error;
+import static me.coley.recaf.util.UiUtil.getFileIcon;
 
 /**
  * Primary menu.
@@ -235,10 +237,16 @@ public class MainMenu extends MenuBar {
 		fcLoadApp.setInitialDirectory(config().getRecentLoadDir());
 		List<File> files = fcLoadApp.showOpenMultipleDialog(null);
 		if (files != null) {
+			final Workspace workspace = controller.getWorkspace();
+
+			if (workspace == null)
+				return;
+
 			for (File file : files) {
 				try {
 					JavaResource resource = FileSystemResource.of(file.toPath());
-					controller.getWorkspace().getLibraries().add(resource);
+
+					workspace.getLibraries().add(resource);
 					controller.windows().getMainWindow().getNavigator().refresh();
 				} catch(Exception ex) {
 					error(ex, "Failed to add library: {}", file.getName());

--- a/src/main/java/me/coley/recaf/ui/MainMenu.java
+++ b/src/main/java/me/coley/recaf/ui/MainMenu.java
@@ -234,13 +234,15 @@ public class MainMenu extends MenuBar {
 	 * Adds a selected resource to the current workspace.
 	 */
 	private void addLibrary() {
+		final Workspace workspace = controller.getWorkspace();
+
+		if (workspace == null)
+			return;
+
 		fcLoadApp.setInitialDirectory(config().getRecentLoadDir());
 		List<File> files = fcLoadApp.showOpenMultipleDialog(null);
-		if (files != null) {
-			final Workspace workspace = controller.getWorkspace();
 
-			if (workspace == null)
-				return;
+		if (files != null) {
 
 			for (File file : files) {
 				try {


### PR DESCRIPTION
## What's new

* Additional check for null in ```me.coley.recaf.ui.MainMenu#addLibrary(...)```

## What's fixed

* ```NullPointerException``` when add library with empty workspace (doesn't loaded jar file):

![image](https://user-images.githubusercontent.com/39193746/86611899-0101bc00-bfb8-11ea-823f-9a94552b6f37.png)
