### PR TITLE
refactor: Remove API flaw

### DIFF
--- a/src/main/java/me/coley/recaf/Recaf.java
+++ b/src/main/java/me/coley/recaf/Recaf.java
@@ -20,9 +20,6 @@ import java.lang.instrument.Instrumentation;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.function.Consumer;
 import java.util.jar.JarFile;
 
 import static me.coley.recaf.util.Log.*;
@@ -39,10 +36,6 @@ public class Recaf {
 	private static Workspace currentWorkspace;
 	private static boolean initialized;
 	private static boolean headless;
-	/**
-	 * Listeners to call when the {@link #currentWorkspace current workspace} is changed.
-	 */
-	private static final Set<Consumer<Workspace>> workspaceSetListeners = new HashSet<>();
 
 	/**
 	 * Start Recaf.
@@ -168,11 +161,6 @@ public class Recaf {
 	 * 		New workspace.
 	 */
 	public static void setCurrentWorkspace(Workspace currentWorkspace) {
-		try {
-			workspaceSetListeners.forEach(listener -> listener.accept(currentWorkspace));
-		} catch(Throwable t) {
-			Log.error(t, "Workspace listener threw an error: {}", t.getMessage());
-		}
 		Recaf.currentWorkspace = currentWorkspace;
 	}
 
@@ -202,13 +190,6 @@ public class Recaf {
 	 */
 	public static Controller getController() {
 		return currentController;
-	}
-
-	/**
-	 * @return Set of listeners to call when the {@link #currentWorkspace current workspace} is changed.
-	 */
-	public static Set<Consumer<Workspace>> getWorkspaceSetListeners() {
-		return workspaceSetListeners;
 	}
 
 	/**

--- a/src/main/java/me/coley/recaf/plugin/PluginsManager.java
+++ b/src/main/java/me/coley/recaf/plugin/PluginsManager.java
@@ -1,6 +1,8 @@
 package me.coley.recaf.plugin;
 
 import me.coley.recaf.plugin.api.BasePlugin;
+import me.coley.recaf.plugin.api.InternalPlugin;
+import me.coley.recaf.plugin.api.InternalApi;
 import me.coley.recaf.util.Log;
 import me.coley.recaf.workspace.EntryLoader;
 import org.plugface.core.PluginContext;
@@ -53,7 +55,8 @@ public class PluginsManager extends DefaultPluginManager {
 		// Collect plugin instances
 		Collection<Object> instances = loadPlugins(source);
 		for (Object instance : instances) {
-			if (instance instanceof BasePlugin) {
+			if (instance instanceof BasePlugin &&
+					!(instance instanceof InternalPlugin)) {
 				BasePlugin plugin = (BasePlugin) instance;
 				String name = plugin.getName();
 				String version = plugin.getVersion();
@@ -63,9 +66,7 @@ public class PluginsManager extends DefaultPluginManager {
 				Log.info("Discovered plugin '{}-{}'", name, version);
 				// PlugFace already has its own internal storage of the plugin instances,
 				// but we want to control them a bit easier. So we'll keep a local reference.
-				plugins.put(name, plugin);
-				pluginStates.put(name, true);
-				pluginIcons.put(name, icon);
+				addPlugin(name, plugin, icon);
 			} else {
 				Log.error("Class '{}' does not extend plugin!", instance.getClass().getName());
 			}
@@ -81,6 +82,16 @@ public class PluginsManager extends DefaultPluginManager {
 	 */
 	public Map<String, BasePlugin> plugins() {
 		return plugins;
+	}
+
+	/**
+	 * @return Collection of visible plugin instances.
+	 */
+	public Map<String, BasePlugin> visiblePlugins() {
+		return plugins.entrySet()
+				.stream()
+				.filter(e -> !(e.getValue() instanceof InternalPlugin))
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 	}
 
 	/**
@@ -138,8 +149,8 @@ public class PluginsManager extends DefaultPluginManager {
 	public <T extends BasePlugin> Collection<T> ofType(Class<T> type) {
 		return plugins().values().stream()
 						.filter(plugin -> type.isAssignableFrom(plugin.getClass()))
-						.map(plugin -> (T) plugin)
 						.filter(plugin -> pluginStates.containsKey(plugin.getName()))
+						.map(plugin -> (T) plugin)
 						.collect(Collectors.toList());
 	}
 
@@ -148,6 +159,50 @@ public class PluginsManager extends DefaultPluginManager {
 	 */
 	public static PluginsManager getInstance() {
 		return INSTANCE;
+	}
+
+	/**
+	 * Registers a plugin.
+	 *
+	 * @param name
+	 * 		Name of the plugin.
+	 * @param plugin
+	 * 		Plugin to register.
+	 * @param icon
+	 * 		Icon of the plugin.
+	 */
+	@InternalApi
+	public void addPlugin(String name, BasePlugin plugin, BufferedImage icon) {
+		plugins.put(name, plugin);
+		pluginStates.put(name, Boolean.TRUE);
+		if (icon != null) {
+			pluginIcons.put(name, icon);
+		}
+	}
+
+	/**
+	 * Registers a plugin.
+	 *
+	 * @param plugin
+	 * 		Plugin to register.
+	 * @param icon
+	 * 		Icon of the plugin.
+	 */
+	@InternalApi
+	public void addPlugin(BasePlugin plugin, BufferedImage icon) {
+		addPlugin(plugin.getName(), plugin, icon);
+	}
+
+
+	/**
+	 * Registers a plugin.
+	 *
+	 * @param plugin
+	 * 		Plugin to register.
+	 */
+	@InternalApi
+	public void addPlugin(BasePlugin plugin) {
+		addPlugin(plugin, null);
 	}
 
 	static {

--- a/src/main/java/me/coley/recaf/plugin/PluginsManager.java
+++ b/src/main/java/me/coley/recaf/plugin/PluginsManager.java
@@ -55,8 +55,7 @@ public class PluginsManager extends DefaultPluginManager {
 		// Collect plugin instances
 		Collection<Object> instances = loadPlugins(source);
 		for (Object instance : instances) {
-			if (instance instanceof BasePlugin &&
-					!(instance instanceof InternalPlugin)) {
+			if (instance instanceof BasePlugin) {
 				BasePlugin plugin = (BasePlugin) instance;
 				String name = plugin.getName();
 				String version = plugin.getVersion();

--- a/src/main/java/me/coley/recaf/plugin/PluginsManager.java
+++ b/src/main/java/me/coley/recaf/plugin/PluginsManager.java
@@ -87,7 +87,7 @@ public class PluginsManager extends DefaultPluginManager {
 	 * @return Collection of visible plugin instances.
 	 */
 	public Map<String, BasePlugin> visiblePlugins() {
-		return plugins.entrySet()
+		return plugins().entrySet()
 				.stream()
 				.filter(e -> !(e.getValue() instanceof InternalPlugin))
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/src/main/java/me/coley/recaf/plugin/PluginsManager.java
+++ b/src/main/java/me/coley/recaf/plugin/PluginsManager.java
@@ -193,7 +193,6 @@ public class PluginsManager extends DefaultPluginManager {
 		addPlugin(plugin.getName(), plugin, icon);
 	}
 
-
 	/**
 	 * Registers a plugin.
 	 *

--- a/src/main/java/me/coley/recaf/plugin/api/InternalApi.java
+++ b/src/main/java/me/coley/recaf/plugin/api/InternalApi.java
@@ -1,0 +1,16 @@
+package me.coley.recaf.plugin.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the method or a class is an internal part
+ * of the API and should not be used directly.
+ *
+ * @author xxDark
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface InternalApi { }

--- a/src/main/java/me/coley/recaf/plugin/api/InternalPlugin.java
+++ b/src/main/java/me/coley/recaf/plugin/api/InternalPlugin.java
@@ -1,0 +1,9 @@
+package me.coley.recaf.plugin.api;
+
+/**
+ * Internal plugin base for Recaf.
+ *
+ * @author xxDark
+ */
+@InternalApi
+public interface InternalPlugin extends BasePlugin { }

--- a/src/main/java/me/coley/recaf/plugin/api/InternalPlugin.java
+++ b/src/main/java/me/coley/recaf/plugin/api/InternalPlugin.java
@@ -1,9 +1,11 @@
 package me.coley.recaf.plugin.api;
 
+import me.coley.recaf.util.InternalElement;
+
 /**
  * Internal plugin base for Recaf.
  *
  * @author xxDark
  */
 @InternalApi
-public interface InternalPlugin extends BasePlugin { }
+public interface InternalPlugin extends BasePlugin, InternalElement { }

--- a/src/main/java/me/coley/recaf/ui/MainMenu.java
+++ b/src/main/java/me/coley/recaf/ui/MainMenu.java
@@ -317,7 +317,10 @@ public class MainMenu extends MenuBar {
 	private void showHistory() {
 		Stage stage = controller.windows().getHistoryWindow();
 		if(stage == null) {
-			stage = controller.windows().window(translate("ui.menubar.history"), new HistoryPane(controller), 800, 600);
+			HistoryPane pane = new HistoryPane(controller);
+			PluginsManager.getInstance()
+					.addPlugin(new HistoryPane.HistoryPlugin(pane));
+			stage = controller.windows().window(translate("ui.menubar.history"), pane, 800, 600);
 			controller.windows().setHistoryWindow(stage);
 		}
 		stage.show();

--- a/src/main/java/me/coley/recaf/ui/MainWindow.java
+++ b/src/main/java/me/coley/recaf/ui/MainWindow.java
@@ -11,6 +11,9 @@ import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 import me.coley.recaf.Recaf;
 import me.coley.recaf.control.gui.GuiController;
+import me.coley.recaf.plugin.PluginsManager;
+import me.coley.recaf.plugin.api.InternalPlugin;
+import me.coley.recaf.plugin.api.WorkspacePlugin;
 import me.coley.recaf.ui.controls.*;
 import me.coley.recaf.ui.controls.popup.UpdateWindow;
 import me.coley.recaf.ui.controls.view.ClassViewport;
@@ -18,6 +21,8 @@ import me.coley.recaf.ui.controls.view.FileViewport;
 import me.coley.recaf.util.ThreadUtil;
 import me.coley.recaf.util.self.SelfUpdater;
 import me.coley.recaf.workspace.JavaResource;
+import me.coley.recaf.workspace.Workspace;
+import org.plugface.core.annotations.Plugin;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.PlatformLoggingMXBean;
@@ -73,7 +78,7 @@ public class MainWindow extends Application {
 		viewRoot.setCenter(tabs);
 		// Navigation
 		updateWorkspaceNavigator();
-		Recaf.getWorkspaceSetListeners().add(w -> updateWorkspaceNavigator());
+		PluginsManager.getInstance().addPlugin(new WindowPlugin());
 		// Create scene & display the window
 		Scene scene = new Scene(root, 800, 600);
 		controller.windows().reapplyStyle(scene);
@@ -252,5 +257,27 @@ public class MainWindow extends Application {
 	 */
 	public void setTitle(String title) {
 		ThreadUtil.checkJfxAndEnqueue(() -> stage.setTitle(title));
+	}
+
+	@Plugin(name = "MainWindow")
+	private final class WindowPlugin implements WorkspacePlugin, InternalPlugin {
+
+		@Override
+		public void onOpened(Workspace workspace) {
+			updateWorkspaceNavigator();
+		}
+
+		@Override
+		public void onClosed(Workspace workspace) { }
+
+		@Override
+		public String getVersion() {
+			return Recaf.VERSION;
+		}
+
+		@Override
+		public String getDescription() {
+			return "Main window UI.";
+		}
 	}
 }

--- a/src/main/java/me/coley/recaf/ui/controls/HistoryPane.java
+++ b/src/main/java/me/coley/recaf/ui/controls/HistoryPane.java
@@ -17,6 +17,7 @@ import me.coley.recaf.plugin.api.WorkspacePlugin;
 import me.coley.recaf.util.ClassUtil;
 import me.coley.recaf.util.LangUtil;
 import me.coley.recaf.util.UiUtil;
+import me.coley.recaf.util.struct.InternalBiConsumer;
 import me.coley.recaf.workspace.History;
 import me.coley.recaf.workspace.JavaResource;
 import me.coley.recaf.workspace.Workspace;
@@ -155,8 +156,10 @@ public class HistoryPane extends BorderPane {
 	 */
 	private void rehookWorkspace() {
 		// Whenever a class/file is updated, call "update()"
-		controller.getWorkspace().getPrimary().getClasses().getPutListeners().add((name, value) -> update());
-		controller.getWorkspace().getPrimary().getFiles().getPutListeners().add((name, value) -> update());
+		controller.getWorkspace().getPrimary().getClasses().getPutListeners()
+				.add(InternalBiConsumer.internal((name, value) -> update()));
+		controller.getWorkspace().getPrimary().getFiles().getPutListeners()
+				.add(InternalBiConsumer.internal((name, value) -> update()));
 	}
 
 	/**

--- a/src/main/java/me/coley/recaf/ui/controls/HistoryPane.java
+++ b/src/main/java/me/coley/recaf/ui/controls/HistoryPane.java
@@ -12,12 +12,16 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import me.coley.recaf.Recaf;
 import me.coley.recaf.control.gui.GuiController;
+import me.coley.recaf.plugin.api.InternalPlugin;
+import me.coley.recaf.plugin.api.WorkspacePlugin;
 import me.coley.recaf.util.ClassUtil;
 import me.coley.recaf.util.LangUtil;
 import me.coley.recaf.util.UiUtil;
 import me.coley.recaf.workspace.History;
 import me.coley.recaf.workspace.JavaResource;
+import me.coley.recaf.workspace.Workspace;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.plugface.core.annotations.Plugin;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -43,7 +47,6 @@ public class HistoryPane extends BorderPane {
 		this.controller = controller;
 		setup();
 		// Ensure access to current/future workspace history maps
-		Recaf.getWorkspaceSetListeners().add(workspace -> rehookWorkspace());
 		if(controller.getWorkspace() != null) {
 			rehookWorkspace();
 			update();
@@ -213,6 +216,40 @@ public class HistoryPane extends BorderPane {
 				setGraphic(null);
 				setText(null);
 			}
+		}
+	}
+
+	/**
+	 * Plugin to rehook workspace.
+	 */
+	@Plugin(name = "History")
+	public static final class HistoryPlugin implements WorkspacePlugin, InternalPlugin {
+		private final HistoryPane history;
+
+		/**
+		 * @param history
+		 * 		History pane.
+		 */
+		public HistoryPlugin(HistoryPane history) {
+			this.history = history;
+		}
+
+		@Override
+		public void onOpened(Workspace workspace) {
+			history.rehookWorkspace();
+		}
+
+		@Override
+		public void onClosed(Workspace workspace) { }
+
+		@Override
+		public String getVersion() {
+			return Recaf.VERSION;
+		}
+
+		@Override
+		public String getDescription() {
+			return "UI to display items history.";
 		}
 	}
 }

--- a/src/main/java/me/coley/recaf/ui/controls/PluginManagerPane.java
+++ b/src/main/java/me/coley/recaf/ui/controls/PluginManagerPane.java
@@ -39,7 +39,7 @@ public class PluginManagerPane extends BorderPane {
 		list.getSelectionModel().selectedItemProperty().addListener((ob, o, n) -> {
 			view.setCenter(createPluginView(n == null ? o : n));
 		});
-		list.setItems(FXCollections.observableArrayList(PluginsManager.getInstance().plugins().values()));
+		list.setItems(FXCollections.observableArrayList(PluginsManager.getInstance().visiblePlugins().values()));
 		view.getStyleClass().add("plugin-view");
 		SplitPane split = new SplitPane(list, view);
 		SplitPane.setResizableWithParent(list, Boolean.FALSE);

--- a/src/main/java/me/coley/recaf/ui/controls/tree/RootItem.java
+++ b/src/main/java/me/coley/recaf/ui/controls/tree/RootItem.java
@@ -1,6 +1,8 @@
 package me.coley.recaf.ui.controls.tree;
 
 import javafx.application.Platform;
+import me.coley.recaf.util.struct.InternalBiConsumer;
+import me.coley.recaf.util.struct.InternalConsumer;
 import me.coley.recaf.workspace.JavaResource;
 
 /**
@@ -22,7 +24,7 @@ public class RootItem extends BaseItem {
 		if(resource.getClasses().size() > 0) {
 			addSourceChild(classes = new ClassFolderItem(resource));
 			// Register listeners and update if the classes update
-			resource.getClasses().getRemoveListeners().add(r -> {
+			resource.getClasses().getRemoveListeners().add(InternalConsumer.internal(r -> {
 				String name = r.toString();
 				DirectoryItem di = classes.getDeepChild(name);
 				if (di != null) {
@@ -39,18 +41,18 @@ public class RootItem extends BaseItem {
 						}
 					});
 				}
-			});
-			resource.getClasses().getPutListeners().add((k, v) -> {
+			}));
+			resource.getClasses().getPutListeners().add(InternalBiConsumer.internal((k, v) -> {
 				// Put includes updates, so only "add" the class when it doesn't already exist
 				if (!resource.getClasses().containsKey(k))
 					Platform.runLater(() -> classes.addClass(k));
-			});
+			}));
 		}
 		// files sub-folder
 		if(resource.getFiles().size() > 0) {
 			addSourceChild(files = new FileFolderItem(resource));
 			// Register listeners and update if the files update
-			resource.getFiles().getRemoveListeners().add(r -> {
+			resource.getFiles().getRemoveListeners().add(InternalConsumer.internal(r -> {
 				String name = r.toString();
 				DirectoryItem di = files.getDeepChild(name);
 				if (di != null) {
@@ -67,12 +69,12 @@ public class RootItem extends BaseItem {
 						}
 					});
 				}
-			});
-			resource.getFiles().getPutListeners().add((k, v) -> {
+			}));
+			resource.getFiles().getPutListeners().add(InternalBiConsumer.internal((k, v) -> {
 				// Put includes updates, so only "add" the file when it doesn't already exist
 				if (!resource.getFiles().containsKey(k))
 					Platform.runLater(() -> files.addFile(k));
-			});
+			}));
 		}
 		// TODO: Sub-folders for these?
 		//  - docs

--- a/src/main/java/me/coley/recaf/util/InternalElement.java
+++ b/src/main/java/me/coley/recaf/util/InternalElement.java
@@ -1,11 +1,15 @@
 package me.coley.recaf.util;
 
+import java.util.function.Predicate;
+
 /**
  * Mark an object as internal.
  *
  * @author xxDark
  */
 public interface InternalElement {
+    Predicate<Object> INTERNAL_PREDICATE = o -> o instanceof InternalElement;
+    Predicate<Object> NOT_INTERNAL_PREDICATE = INTERNAL_PREDICATE.negate();
 
     /**
      * Helper method to check if the object

--- a/src/main/java/me/coley/recaf/util/InternalElement.java
+++ b/src/main/java/me/coley/recaf/util/InternalElement.java
@@ -1,0 +1,22 @@
+package me.coley.recaf.util;
+
+/**
+ * Mark an object as internal.
+ *
+ * @author xxDark
+ */
+public interface InternalElement {
+
+    /**
+     * Helper method to check if the object
+     * is marked as internal or not.
+     *
+     * @param object
+     *      Object to check.
+     *
+     * @return {@code true} if object is internal, {@code false} otherwise.
+     */
+    static boolean isInternal(Object object) {
+        return object instanceof InternalElement;
+    }
+}

--- a/src/main/java/me/coley/recaf/util/struct/InternalBiConsumer.java
+++ b/src/main/java/me/coley/recaf/util/struct/InternalBiConsumer.java
@@ -1,0 +1,28 @@
+package me.coley.recaf.util.struct;
+
+import me.coley.recaf.plugin.api.InternalApi;
+import me.coley.recaf.util.InternalElement;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Internal listener for Recaf purposes.
+ *
+ * @author xxDark
+ */
+@InternalApi
+@FunctionalInterface
+public interface InternalBiConsumer<T, U> extends BiConsumer<T, U>, InternalElement {
+
+    /**
+     * Wraps bi consumer into internal listener.
+     *
+     * @param consumer
+     *      Original bi consumer.
+     * @return
+     *      BiConsumer wrapped into internal listener.
+     */
+    static <T, U> InternalBiConsumer<T, U> internal(BiConsumer<T, U> consumer) {
+        return consumer::accept;
+    }
+}

--- a/src/main/java/me/coley/recaf/util/struct/InternalBiConsumer.java
+++ b/src/main/java/me/coley/recaf/util/struct/InternalBiConsumer.java
@@ -8,6 +8,11 @@ import java.util.function.BiConsumer;
 /**
  * Internal listener for Recaf purposes.
  *
+ * @param <T>
+ *     First type of an object.
+ * @param <U>
+ *     Second type an object.
+ *
  * @author xxDark
  */
 @InternalApi
@@ -19,6 +24,10 @@ public interface InternalBiConsumer<T, U> extends BiConsumer<T, U>, InternalElem
      *
      * @param consumer
      *      Original bi consumer.
+     * @param <T>
+     *     First type of an object.
+     * @param <U>
+     *     Second type an object.
      * @return
      *      BiConsumer wrapped into internal listener.
      */

--- a/src/main/java/me/coley/recaf/util/struct/InternalConsumer.java
+++ b/src/main/java/me/coley/recaf/util/struct/InternalConsumer.java
@@ -1,0 +1,28 @@
+package me.coley.recaf.util.struct;
+
+import me.coley.recaf.plugin.api.InternalApi;
+import me.coley.recaf.util.InternalElement;
+
+import java.util.function.Consumer;
+
+/**
+ * Internal listener for Recaf purposes.
+ *
+ * @author xxDark
+ */
+@InternalApi
+@FunctionalInterface
+public interface InternalConsumer<T> extends Consumer<T>, InternalElement {
+
+    /**
+     * Wraps consumer into internal listener.
+     *
+     * @param consumer
+     *      Original consumer.
+     * @return
+     *      Consumer wrapped into internal listener.
+     */
+    static <T> InternalConsumer<T> internal(Consumer<T> consumer) {
+        return consumer::accept;
+    }
+}

--- a/src/main/java/me/coley/recaf/util/struct/InternalConsumer.java
+++ b/src/main/java/me/coley/recaf/util/struct/InternalConsumer.java
@@ -8,6 +8,9 @@ import java.util.function.Consumer;
 /**
  * Internal listener for Recaf purposes.
  *
+ * @param <T>
+ *     Type of an object.
+ *
  * @author xxDark
  */
 @InternalApi
@@ -19,6 +22,8 @@ public interface InternalConsumer<T> extends Consumer<T>, InternalElement {
      *
      * @param consumer
      *      Original consumer.
+     * @param <T>
+     *     Type of an object.
      * @return
      *      Consumer wrapped into internal listener.
      */

--- a/src/main/java/me/coley/recaf/util/struct/VMUtil.java
+++ b/src/main/java/me/coley/recaf/util/struct/VMUtil.java
@@ -19,7 +19,7 @@ public final class VMUtil {
     private VMUtil() { }
 
     /**
-     * Appends URL to the {@link URLClassLoader}
+     * Appends URL to the {@link URLClassLoader}.
      *
      * @param cl  the classloader to add {@link URL} for.
      * @param url the {@link URL} to add.
@@ -100,7 +100,7 @@ public final class VMUtil {
     }
 
     /**
-     * Closes {@link URLClassLoader}
+     * Closes {@link URLClassLoader}.
      *
      * @param loader
      *      Loader to close.

--- a/src/main/java/me/coley/recaf/util/struct/VMUtil.java
+++ b/src/main/java/me/coley/recaf/util/struct/VMUtil.java
@@ -52,7 +52,7 @@ public final class VMUtil {
         } catch (IllegalAccessException ex) {
             throw new IllegalStateException("'addURL' became inaccessible", ex);
         } catch (InvocationTargetException ex) {
-            throw new RuntimeException("Error adding URL", ex.getCause());
+            throw new RuntimeException("Error adding URL", ex.getTargetException());
         }
     }
 
@@ -93,9 +93,32 @@ public final class VMUtil {
             } catch (IllegalAccessException ex) {
                 throw new IllegalStateException("'addURL' became inaccessible", ex);
             } catch (InvocationTargetException ex) {
-                throw new RuntimeException("Error adding URL", ex.getCause());
+                throw new RuntimeException("Error adding URL", ex.getTargetException());
             }
         } while ((currentClass=currentClass.getSuperclass()) != Object.class);
         throw new IllegalArgumentException("No 'ucp' field in " + loader);
+    }
+
+    /**
+     * Closes {@link URLClassLoader}
+     *
+     * @param loader
+     *      Loader to close.
+     */
+    public static void close(URLClassLoader loader) {
+        Method method;
+        try {
+            method = URLClassLoader.class.getDeclaredMethod("close");
+        } catch (NoSuchMethodException ex) {
+            throw new RuntimeException("No 'close' method in java.net.URLClassLoader", ex);
+        }
+        method.setAccessible(true);
+        try {
+            method.invoke(loader);
+        } catch (IllegalAccessException ex) {
+            throw new IllegalStateException("'close' became inaccessible", ex);
+        } catch (InvocationTargetException ex) {
+            throw new RuntimeException("Error closing loader", ex.getTargetException());
+        }
     }
 }

--- a/src/main/java/me/coley/recaf/workspace/JavaResource.java
+++ b/src/main/java/me/coley/recaf/workspace/JavaResource.java
@@ -265,7 +265,8 @@ public abstract class JavaResource {
 					if (!isPrimary())
 						return cachedFiles;
 					// Register listeners
-					cachedFiles.getPutListeners().add(InternalBiConsumer.internal((name, code) -> dirtyFiles.add(name)));
+					cachedFiles.getPutListeners()
+							.add(InternalBiConsumer.internal((name, code) -> dirtyFiles.add(name)));
 					cachedFiles.getRemoveListeners().add(InternalConsumer.internal(dirtyFiles::remove));
 					// Create initial save state
 					for (Map.Entry<String, byte[]> e : cachedFiles.entrySet()) {
@@ -289,12 +290,12 @@ public abstract class JavaResource {
 	 * Refresh this resource.
 	 */
 	public void invalidate() {
-		cachedFiles.getPutListeners().removeIf(InternalElement::isInternal);
-		cachedFiles.getRemoveListeners().removeIf(InternalElement::isInternal);
+		cachedFiles.getPutListeners().removeIf(InternalElement.INTERNAL_PREDICATE);
+		cachedFiles.getRemoveListeners().removeIf(InternalElement.INTERNAL_PREDICATE);
 		cachedFiles.clear();
 		cachedFiles.setBacking(null);
-		cachedClasses.getPutListeners().removeIf(InternalElement::isInternal);
-		cachedClasses.getRemoveListeners().removeIf(InternalElement::isInternal);
+		cachedClasses.getPutListeners().removeIf(InternalElement.INTERNAL_PREDICATE);
+		cachedClasses.getRemoveListeners().removeIf(InternalElement.INTERNAL_PREDICATE);
 		cachedClasses.clear();
 		cachedClasses.setBacking(null);
 		classDocs.clear();

--- a/src/main/java/me/coley/recaf/workspace/JavaResource.java
+++ b/src/main/java/me/coley/recaf/workspace/JavaResource.java
@@ -6,6 +6,9 @@ import me.coley.recaf.parse.javadoc.DocumentationParseException;
 import me.coley.recaf.parse.javadoc.Javadocs;
 import me.coley.recaf.parse.source.SourceCode;
 import me.coley.recaf.parse.source.SourceCodeException;
+import me.coley.recaf.util.InternalElement;
+import me.coley.recaf.util.struct.InternalBiConsumer;
+import me.coley.recaf.util.struct.InternalConsumer;
 import me.coley.recaf.util.struct.ListeningMap;
 import org.apache.commons.io.IOUtils;
 
@@ -229,18 +232,19 @@ public abstract class JavaResource {
 					if (!isPrimary())
 						return cachedClasses;
 					// Register listeners
-					cachedClasses.getPutListeners().add((name, code) -> dirtyClasses.add(name));
-					cachedClasses.getRemoveListeners().add(dirtyClasses::remove);
+					cachedClasses.getPutListeners()
+							.add(InternalBiConsumer.internal((name, code) -> dirtyClasses.add(name)));
+					cachedClasses.getRemoveListeners().add(InternalConsumer.internal(dirtyClasses::remove));
 					// Create initial save state
 					for (Map.Entry<String, byte[]> e : cachedClasses.entrySet()) {
 						addClassSave(e.getKey(), e.getValue());
 					}
 					// Add listener to create initial save states for newly made classes
-					cachedClasses.getPutListeners().add((name, code) -> {
+					cachedClasses.getPutListeners().add(InternalBiConsumer.internal((name, code) -> {
 						if (!cachedClasses.containsKey(name)) {
 							addClassSave(name, code);
 						}
-					});
+					}));
 				} catch(IOException ex) {
 					error(ex, "Failed to load classes from resource \"{}\"", toString());
 				}
@@ -261,18 +265,18 @@ public abstract class JavaResource {
 					if (!isPrimary())
 						return cachedFiles;
 					// Register listeners
-					cachedFiles.getPutListeners().add((name, code) -> dirtyFiles.add(name));
-					cachedFiles.getRemoveListeners().add(dirtyFiles::remove);
+					cachedFiles.getPutListeners().add(InternalBiConsumer.internal((name, code) -> dirtyFiles.add(name)));
+					cachedFiles.getRemoveListeners().add(InternalConsumer.internal(dirtyFiles::remove));
 					// Create initial save state
 					for (Map.Entry<String, byte[]> e : cachedFiles.entrySet()) {
 						addFileSave(e.getKey(), e.getValue());
 					}
 					// Add listener to create initial save states for newly made files
-					cachedFiles.getPutListeners().add((name, code) -> {
+					cachedFiles.getPutListeners().add(InternalBiConsumer.internal((name, code) -> {
 						if (!cachedFiles.containsKey(name)) {
 							addFileSave(name, code);
 						}
-					});
+					}));
 				}
 			} catch(IOException ex) {
 				error(ex, "Failed to load files from resource \"{}\"", toString());
@@ -285,13 +289,12 @@ public abstract class JavaResource {
 	 * Refresh this resource.
 	 */
 	public void invalidate() {
-		// TODO: Store old listeners (not the defaults, the user-added ones) to copy over to new maps
-		cachedFiles.getPutListeners().clear();
-		cachedFiles.getRemoveListeners().clear();
+		cachedFiles.getPutListeners().removeIf(InternalElement::isInternal);
+		cachedFiles.getRemoveListeners().removeIf(InternalElement::isInternal);
 		cachedFiles.clear();
 		cachedFiles.setBacking(null);
-		cachedClasses.getPutListeners().clear();
-		cachedClasses.getRemoveListeners().clear();
+		cachedClasses.getPutListeners().removeIf(InternalElement::isInternal);
+		cachedClasses.getRemoveListeners().removeIf(InternalElement::isInternal);
 		cachedClasses.clear();
 		cachedClasses.setBacking(null);
 		classDocs.clear();


### PR DESCRIPTION
## What's new
Before that commit, Recaf kept additional set of workspace listeners for it's own purposes.
This PR remove that set, and adds internal plugins instead.
Everything that must not be used by plugin developers is marked as `@InternalApi`. However, that also allows users to load/unload plugins on-the-fly.
