### PR TITLE
feat: Support parsing error recovery

### DIFF
--- a/src/main/java/me/coley/recaf/ui/controls/text/JavaContextHandling.java
+++ b/src/main/java/me/coley/recaf/ui/controls/text/JavaContextHandling.java
@@ -67,6 +67,14 @@ public class JavaContextHandling extends ContextHandling {
 		this.code = code;
 	}
 
+	/**
+	 * @return
+	 *      Analyzed code.
+	 */
+	public SourceCode getCode() {
+		return code;
+	}
+
 	private void handleClassType(ClassSelection selection) {
 		codeArea.setContextMenu(menu().controller(controller)
 				.view(getViewport())

--- a/src/main/java/me/coley/recaf/ui/controls/text/JavaEditorPane.java
+++ b/src/main/java/me/coley/recaf/ui/controls/text/JavaEditorPane.java
@@ -1,11 +1,14 @@
 package me.coley.recaf.ui.controls.text;
 
+import com.github.javaparser.ParseResult;
 import com.github.javaparser.Range;
+import com.github.javaparser.ast.CompilationUnit;
 import javafx.application.Platform;
 import me.coley.recaf.compiler.JavacCompiler;
 import me.coley.recaf.compiler.TargetVersion;
 import me.coley.recaf.control.gui.GuiController;
 import me.coley.recaf.parse.source.SourceCode;
+import me.coley.recaf.parse.source.SourceCodeException;
 import me.coley.recaf.ui.controls.ClassEditor;
 import me.coley.recaf.ui.controls.text.model.Languages;
 import me.coley.recaf.util.*;
@@ -52,18 +55,39 @@ public class JavaEditorPane extends EditorPane<JavaErrorHandling, JavaContextHan
 		if (initialText != null)
 			setText(initialText);
 		setErrorHandler(new JavaErrorHandling(this));
-		setOnCodeChange(text -> getErrorHandler().onCodeChange(() -> {
-			code = new SourceCode(resource, getText());
-			code.analyze(controller.getWorkspace());
-			docHandler = new JavaDocHandling(this, controller, code);
-			contextHandler.setCode(code);
-		}));
+		setOnCodeChange(text -> getErrorHandler().onCodeChange(this::parseCode));
 		setOnKeyReleased(e -> {
 			if(controller.config().keys().gotoDef.match(e))
 				contextHandler.gotoSelectedDef();
 			else if(controller.config().keys().rename.match(e))
 				contextHandler.openRenameInput();
 		});
+	}
+
+	private void parseCode() throws SourceCodeException {
+		code = new SourceCode(resource, getText());
+		try {
+			code.analyze(controller.getWorkspace());
+		} catch (SourceCodeException e) {
+			if (JavaParserUtil.isCompilationUnitParseable(code.getUnit())) {  // Also accept partial result
+				docHandler = new JavaDocHandling(this, controller, code);
+				contextHandler.setCode(code);
+			} else if (contextHandler.getCode() == null) {  // If the code has never been parsed successfully before now
+				ParseResult<CompilationUnit> parseResult = code.analyzeFiltered(controller.getWorkspace(),
+						e.getResult().getProblems());
+				if (parseResult.isSuccessful() || parseResult.getResult()
+						.filter(JavaParserUtil::isCompilationUnitParseable).isPresent()) {
+					docHandler = new JavaDocHandling(this, controller, code);
+					contextHandler.setCode(code);
+
+					// We've got the basics parsed and working. Time to reset the unit back to
+					// the original source (with `contextHandler.getCode()` not longer null).
+					// This will throw the same SourceCodeException
+					parseCode();
+				}
+			}
+			throw e;
+		}
 	}
 
 	@Override

--- a/src/main/java/me/coley/recaf/util/JavaParserUtil.java
+++ b/src/main/java/me/coley/recaf/util/JavaParserUtil.java
@@ -1,6 +1,8 @@
 package me.coley.recaf.util;
 
+import com.github.javaparser.Problem;
 import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
@@ -15,13 +17,20 @@ import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.resolution.types.ResolvedTypeVariable;
 import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParserFieldDeclaration;
+import com.google.common.collect.*;
 import me.coley.recaf.parse.source.SourceCode;
 import me.coley.recaf.ui.controls.text.selection.ClassSelection;
 import me.coley.recaf.ui.controls.text.selection.MemberSelection;
 import org.fxmisc.richtext.model.TwoDimensional;
 
+import java.io.IOException;
+import java.io.LineNumberReader;
+import java.io.StringReader;
 import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * JavaParser utilities.
@@ -30,6 +39,77 @@ import java.util.Optional;
  */
 public class JavaParserUtil {
 	private static Method GET_SOLVER;
+
+	/**
+	 * Clean up the source code generated from decompiler and filter out the problems.
+	 *
+	 * @param code
+	 *      Source to clean up.
+	 * @param problems
+	 *      Known problems.
+	 * @return
+	 *      Cleaned source for parsing
+	 */
+	public static String filterDecompiledCode(String code, Collection<Problem> problems) {
+		ListMultimap<Integer, Problem> problemMap = MultimapBuilder.ListMultimapBuilder
+				.treeKeys()
+				.arrayListValues()
+				.build(problems.stream()
+					.filter(p -> p.getLocation().flatMap(TokenRange::toRange).isPresent())
+					.collect(ImmutableListMultimap.toImmutableListMultimap(p ->
+							p.getLocation().flatMap(TokenRange::toRange).get().begin.line, Function.identity())));
+
+		StringBuilder builder = new StringBuilder(code.length());
+		try (LineNumberReader reader = new LineNumberReader(new StringReader(code))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				int ln = reader.getLineNumber();
+				boolean commentOut = false;
+
+				List<Problem> lineProblems = problemMap.get(ln);  // Check the current line
+				if (!lineProblems.isEmpty() && lineProblems.stream().map(Problem::getMessage)
+						.noneMatch(m -> m.contains("expected \"}\"") || m.contains("expected \"{\""))) {
+					commentOut = true;
+				}
+
+				lineProblems = problemMap.get(ln - 1);  // Check the pervious line
+				if (!lineProblems.isEmpty() && lineProblems.stream().map(Problem::getMessage)
+						.anyMatch(m -> m.contains("expected \"}\""))) {
+					commentOut = true;
+				}
+
+				lineProblems = problemMap.get(ln + 1);  // Check the next line
+				if (!lineProblems.isEmpty() && lineProblems.stream().map(Problem::getMessage)
+						.anyMatch(m -> m.contains("expected \"{\""))) {
+					commentOut = true;
+				}
+
+				// CFR is known to sometimes generate pseudocode that starts with **
+				// Other decompilers seems to comment out theirs nicely.
+				if (!commentOut && line.trim().startsWith("** ")) {
+					commentOut = true;
+				}
+
+				if (commentOut) builder.append("//");
+				builder.append(line).append('\n');
+			}
+		} catch (IOException e) {
+			throw new AssertionError(e);
+		}
+		return builder.toString();
+	}
+
+	/**
+	 * Check if the specified compliation unit is considered parsed.
+	 *
+	 * @param unit
+	 *      the compliation unit
+	 * @return
+	 *      {@code false} if unparseable
+	 */
+	public static boolean isCompilationUnitParseable(CompilationUnit unit) {
+		return unit != null && unit.getParsed() == Node.Parsedness.PARSED;
+	}
 
 	/**
 	 * Fetch type of selection from the given position.
@@ -93,6 +173,11 @@ public class JavaParserUtil {
 	 */
 	private static Object checkForDeclaredSelection(SymbolResolver solver, Node node) {
 		try {
+			CompilationUnit unit = node.findCompilationUnit().orElseThrow(AssertionError::new);
+			if (solver != null && !unit.containsData(Node.SYMBOL_RESOLVER_KEY)) {
+				unit.setData(Node.SYMBOL_RESOLVER_KEY, solver);
+			}
+
 			if(node instanceof TypeDeclaration) {
 				ResolvedReferenceTypeDeclaration dec = ((TypeDeclaration) node).resolve();
 				String name = toInternal(dec);


### PR DESCRIPTION
After [this conversation](https://github.com/Col-E/Recaf/issues/274#issuecomment-691491953) I've been doing some research. It seems that JavaParser [already supports some level of error recovery](https://github.com/javaparser/javaparser/pull/952), but currently there're two problems with this:
1. Recaf throws out the parse result immediately when it contains any error.
2. The kinds of recovery JavaParser can do are limited, especially when the class structure is compromised. This unfortunately happens a lot with obfuscated code in CFR.

For the first problem, we can instead check `CompilationUnit.getParsed()` against `Parsedness.PARSED`. The result in such case may not be fully formed, but after the patch on `JavaParserUtil.checkForDeclaredSelection()` it seems to be working without problem.

For the second one, we can try to comment out lines that could be causing us problem and use the result under-the-hood. There aren't any symbols to be parsed in comments, so the resulting AST should still correctly map to the original source. Furthermore, this workaround will only be used when parsing haven't succeed at least once and there ain't any info for context actions yet. This is 
 in part to prevent it from giving out inconsistent result while users are modifying the code. It isn't the most graceful of solutions, but it seems to work well enough in my testing.

![](https://user-images.githubusercontent.com/12008103/93617599-c3360080-fa08-11ea-9d81-12f24ebd0f21.png)