### PR TITLE
feat: Track applied renames in workspace and enable mapping export

### DIFF
--- a/src/main/java/me/coley/recaf/config/ConfBackend.java
+++ b/src/main/java/me/coley/recaf/config/ConfBackend.java
@@ -39,6 +39,11 @@ public class ConfBackend extends Config {
 	@Conf("backend.recentsave")
 	public String recentSaveWorkspace = CURRENT_DIR;
 	/**
+	 * Recent path used by the save-map dialog.
+	 */
+	@Conf("backend.recentsave")
+	public String recentSaveMap = CURRENT_DIR;
+	/**
 	 * Check to determine if user should be told to read the documentation.
 	 */
 	@Conf("backend.firsttime")
@@ -103,6 +108,14 @@ public class ConfBackend extends Config {
 	 */
 	public File getRecentSaveWorkspaceDir() {
 		return getDir(recentSaveWorkspace);
+	}
+
+	/**
+	 * @return Directory to use for save-map file-chooser.
+	 * Based on the most recent file exported.
+	 */
+	public File getRecentSaveMapDir() {
+		return getDir(recentSaveMap);
 	}
 
 	private File getDir(String root) {

--- a/src/main/java/me/coley/recaf/config/ConfBackend.java
+++ b/src/main/java/me/coley/recaf/config/ConfBackend.java
@@ -31,17 +31,17 @@ public class ConfBackend extends Config {
 	/**
 	 * Recent path used by the save-application dialog.
 	 */
-	@Conf("backend.recentsave")
+	@Conf("backend.recentsave.app")
 	public String recentSaveApp = CURRENT_DIR;
 	/**
 	 * Recent path used by the save-workspace dialog.
 	 */
-	@Conf("backend.recentsave")
+	@Conf("backend.recentsave.workspace")
 	public String recentSaveWorkspace = CURRENT_DIR;
 	/**
 	 * Recent path used by the save-map dialog.
 	 */
-	@Conf("backend.recentsave")
+	@Conf("backend.recentsave.map")
 	public String recentSaveMap = CURRENT_DIR;
 	/**
 	 * Check to determine if user should be told to read the documentation.

--- a/src/main/java/me/coley/recaf/mapping/AsmMappingUtils.java
+++ b/src/main/java/me/coley/recaf/mapping/AsmMappingUtils.java
@@ -1,0 +1,161 @@
+package me.coley.recaf.mapping;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Util class to work with ASM mappings based on String operations, such as extracting portions of ASM mapping keys or
+ * folding new mappings onto an existing mapping.
+ */
+public class AsmMappingUtils {
+    private AsmMappingUtils() {
+        // static class
+    }
+
+    /**
+     * Extracts the fully qualified class name portion from a mapping key in ASM format.
+     * (See {@link org.objectweb.asm.commons.SimpleRemapper#SimpleRemapper(Map)}) for format information.
+     *
+     * @param asmKey ASM mapping key to extract the fully qualified class name from.
+     * @return Fully qualified class name of the given ASM mapping key or {@code null} if this is not applicable.
+     */
+    public static String getClassNameFromAsmKey(String asmKey) {
+        // Don't map constructors/static-initializers
+        if (asmKey.contains("<"))
+            return null;
+
+        boolean isMember = asmKey.contains(".");
+        if (!isMember) {
+            // This is a class, just return the original mapping key
+            return asmKey;
+        }
+
+        // Check if the key indicates an invoke-dynamic call
+        // Don't return anything for invokdynamic
+        boolean isInvokeDynamic = asmKey.charAt(0) == '.';
+        if (isInvokeDynamic)
+            return null;
+
+        int dotIndex = asmKey.indexOf('.');
+        return asmKey.substring(0, dotIndex);
+    }
+
+    /**
+     * Applies a new mapping in ASM format (See {@link org.objectweb.asm.commons.SimpleRemapper#SimpleRemapper(Map)})
+     * to an existing mapping in ASM format. This will handle transitive renames ({@code a -> b -> c} by compressing
+     * them down to their ultimate result ({@code a -> c}).
+     * When this method is used for every update of the mappings, the resulting mapping can be applied to the original
+     * class files to achieve the same result again.
+     *
+     * <p>Note that the exiting mapping is modified by this method!
+     *
+     * @param existing   Existing ASM mapping to be updated with the additional mappings.
+     * @param additional Additional ASM mappings to update the original mapping with.
+     */
+    public static void applyMappingToExisting(Map<String, String> existing, Map<String, String> additional) {
+        Map<String, String> keyToKeyMapping = transformAsmMappingValuesToKeyFormat(existing);
+        Multimap<String, String> inverseMapping =
+                Multimaps.invertFrom(Multimaps.forMap(keyToKeyMapping), ArrayListMultimap.create());
+
+        Map<String, String> preimageAwareUpdates = new HashMap<>();
+        for (Map.Entry<String, String> entry : additional.entrySet()) {
+            String key = entry.getKey();
+            final String value = entry.getValue();
+            entry = null; // don't use the original entry anymore as we might modify the key
+
+            boolean isMember = key.contains(".");
+            if (isMember) {
+                /* With members we need to take special care:
+                   The user might have renamed com/example/MyClass to com/example/MyAwesomeClass before and now renamed
+                   com/example/MyAwesomeClass.MY_CONSTANT to com/example/MyAwesomeClass.MY_AWESOME_CONSTANT.
+                   In this case we want to create the mapping "com/example/MyClass.MY_CONSTANT MY_AWESOME_CONSTANT". */
+                String className = getClassNameFromAsmKey(key);
+                Collection<String> classPreimages = inverseMapping.get(className);
+                if (classPreimages.size() > 1) {
+                    throw new IllegalStateException("Reverse mapping of class" + className + " while reverse mapping "
+                            + key + " gave more than 1 result: " + String.join(", " + classPreimages));
+                }
+                // if we have a preimage for the class, apply the mapping to that preimage class name
+                if (classPreimages.size() == 1) {
+                    String classPreimage = classPreimages.iterator().next();
+                    String memberName = key.substring(key.indexOf('.') + 1);
+                    key = classPreimage + "." + memberName;
+                }
+            }
+
+            // check if this class/member has been mapped before and transform the mapping accordingly
+            Collection<String> preimages = inverseMapping.get(key);
+            if (preimages.size() > 1) {
+                throw new IllegalStateException("Reverse mapping of " + key
+                        + " gave more than 1 result: " + String.join(", " + preimages));
+            }
+            if (preimages.size() == 1) {
+                preimageAwareUpdates.put(preimages.iterator().next(), value);
+            } else {
+                preimageAwareUpdates.put(key, value);
+            }
+        }
+
+        existing.putAll(preimageAwareUpdates);
+    }
+
+    /**
+     * Transforms a given mapping in ASM format (See
+     * {@link org.objectweb.asm.commons.SimpleRemapper#SimpleRemapper(Map)}) to a mapping where the values are in the
+     * key format of ASM mappings. This allows using the new value as keys for another transformation step.
+     *
+     * <p>For example the mapping {@code calc/MyCalculator.MAX_DEPTH -> MAX_DEPTH_LEVEL} will be transformed to
+     * {@code calc/MyCalculator.MAX_DEPTH -> calc/Calculator.MAX_DEPTH_LEVEL}
+     *
+     * @param mapping ASM mapping to transform.
+     * @return Transformed mapping where the value would be a valid key for another ASM transformation step.
+     */
+    public static Map<String, String> transformAsmMappingValuesToKeyFormat(Map<String, String> mapping) {
+        return mapping.entrySet().stream()
+                .map(AsmMappingUtils::transformSingleAsmMappingToKeyFormat)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static Map.Entry<String, String> transformSingleAsmMappingToKeyFormat(Map.Entry<String, String> mapping) {
+        // Heavily inspired by SimpleRecordingRemapper.map()
+        String key = mapping.getKey();
+        String value = mapping.getValue();
+
+        // Don't map constructors/static-initializers
+        if (key.contains("<"))
+            return null;
+
+        boolean isMember = key.contains(".");
+        if (!isMember) {
+            // This is a class, just return the original mapping as its value is the applied value
+            return mapping;
+        }
+
+        // Don't map invokedynamic calls
+        boolean isInvokeDynamic = key.charAt(0) == '.';
+        if (isInvokeDynamic)
+            return null;
+
+        int braceIndex = key.indexOf('(');
+        boolean isMethod = braceIndex != -1;
+        int dotIndex = key.indexOf('.');
+        String className = key.substring(0, dotIndex);
+        if (!isMethod) {
+            String newName = className + "." + value;
+            return new AbstractMap.SimpleEntry<>(key, newName);
+        }
+
+        String descriptor = key.substring(braceIndex);
+        String newName = className + "." + value + descriptor;
+        return new AbstractMap.SimpleEntry<>(key, newName);
+    }
+}

--- a/src/main/java/me/coley/recaf/mapping/Mappings.java
+++ b/src/main/java/me/coley/recaf/mapping/Mappings.java
@@ -148,6 +148,8 @@ public class Mappings {
 		workspace.onPrimaryDefinitionChanges(updated.keySet());
 		// Update hierarchy graph
 		workspace.getHierarchyGraph().refresh();
+		// Update saved mappings
+		workspace.updateAggregateMappings(getMappings(), updated.keySet());
 		return updated;
 	}
 

--- a/src/main/resources/translations/en.json
+++ b/src/main/resources/translations/en.json
@@ -53,6 +53,8 @@
 	"ui.fileprompt.workspace.extensions": "Recaf workspaces",
 	"ui.fileprompt.mapping": "Select mappings",
 	"ui.fileprompt.mapping.extensions": "Mappings",
+	"ui.fileprompt.export.mapping": "Save mappings",
+	"ui.fileprompt.export.mapping.extensions": "Simple mappings",
 
 	"ui.menubar.file": "File",
 	"ui.menubar.file.addlib": "Add library",
@@ -64,6 +66,7 @@
 	"ui.menubar.file.agentexport": "Apply changes",
 	"ui.menubar.mapping": "Mappings",
 	"ui.menubar.mapping.apply": "Apply map file",
+	"ui.menubar.mapping.export": "Export map file in Simple format",
 	"ui.menubar.config": "Config",
 	"ui.menubar.themeeditor": "Theme editor",
 	"ui.menubar.search": "Search",

--- a/src/test/java/me/coley/recaf/mapping/AsmMappingUtilsTest.java
+++ b/src/test/java/me/coley/recaf/mapping/AsmMappingUtilsTest.java
@@ -1,0 +1,79 @@
+package me.coley.recaf.mapping;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for the solely String-based methods of {@link AsmMappingUtils}.
+ */
+public class AsmMappingUtilsTest {
+    @Test
+    public void testSimpleKeyToKeyTransformation() {
+        Map<String, String> inputMapping = new HashMap<>();
+        inputMapping.put("calc/Calculator.MAX_DEPTH", "MAX_DEPTH_LEVEL");
+        inputMapping.put("calc/Calculator.evaluate(ILjava/lang/String;)D", "doEvaluate");
+
+        Map<String, String> resultMapping = AsmMappingUtils.transformAsmMappingValuesToKeyFormat(inputMapping);
+
+        assertEquals(2, resultMapping.size());
+        assertEquals("calc/Calculator.MAX_DEPTH_LEVEL", resultMapping.get("calc/Calculator.MAX_DEPTH"));
+        assertEquals("calc/Calculator.doEvaluate(ILjava/lang/String;)D",
+                resultMapping.get("calc/Calculator.evaluate(ILjava/lang/String;)D"));
+    }
+
+    @Test
+    public void testApplyMappingToExistingOnRenamedClass() {
+        Map<String, String> aggregateMapping = new HashMap<>();
+        aggregateMapping.put("calc/Calculator", "renamed/MyCalc");
+
+        Map<String, String> additionalMapping = new HashMap<>();
+        additionalMapping.put("renamed/MyCalc.evaluate(ILjava/lang/String;)D", "doEvaluate");
+        additionalMapping.put("renamed/MyCalc.MAX_DEPTH", "MAX_DEPTH_LEVEL");
+
+        AsmMappingUtils.applyMappingToExisting(aggregateMapping, additionalMapping);
+
+        assertEquals(3, aggregateMapping.size());
+        assertEquals("renamed/MyCalc", aggregateMapping.get("calc/Calculator"));
+        assertEquals("MAX_DEPTH_LEVEL", aggregateMapping.get("calc/Calculator.MAX_DEPTH"));
+        assertEquals("doEvaluate", aggregateMapping.get("calc/Calculator.evaluate(ILjava/lang/String;)D"));
+    }
+
+    @Test
+    public void testApplyMappingToExistingClassRename() {
+        Map<String, String> aggregateMapping = new HashMap<>();
+        aggregateMapping.put("calc/Calculator.evaluate(ILjava/lang/String;)D", "doEvaluate");
+        aggregateMapping.put("calc/Calculator.MAX_DEPTH", "MAX_DEPTH_LEVEL");
+
+        Map<String, String> additionalMapping = new HashMap<>();
+        additionalMapping.put("calc/Calculator", "renamed/MyCalc");
+
+        AsmMappingUtils.applyMappingToExisting(aggregateMapping, additionalMapping);
+
+        assertEquals(3, aggregateMapping.size());
+        assertEquals("renamed/MyCalc", aggregateMapping.get("calc/Calculator"));
+        assertEquals("MAX_DEPTH_LEVEL", aggregateMapping.get("calc/Calculator.MAX_DEPTH"));
+        assertEquals("doEvaluate", aggregateMapping.get("calc/Calculator.evaluate(ILjava/lang/String;)D"));
+    }
+
+    @Test
+    public void testApplyMappingToExistingTransitiveRenames() {
+        Map<String, String> aggregateMapping = new HashMap<>();
+        aggregateMapping.put("calc/Calculator.evaluate(ILjava/lang/String;)D", "doEvaluate");
+        aggregateMapping.put("calc/Calculator.MAX_DEPTH", "MAX_DEPTH_LEVEL");
+        aggregateMapping.put("calc/Calculator", "renamed/MyCalc");
+
+        Map<String, String> additionalMapping = new HashMap<>();
+        additionalMapping.put("renamed/MyCalc", "renamed2/MyCalc2");
+
+        AsmMappingUtils.applyMappingToExisting(aggregateMapping, additionalMapping);
+
+        assertEquals(3, aggregateMapping.size());
+        assertEquals("renamed2/MyCalc2", aggregateMapping.get("calc/Calculator"));
+        assertEquals("MAX_DEPTH_LEVEL", aggregateMapping.get("calc/Calculator.MAX_DEPTH"));
+        assertEquals("doEvaluate", aggregateMapping.get("calc/Calculator.evaluate(ILjava/lang/String;)D"));
+    }
+}


### PR DESCRIPTION
First, thanks for creating this project! This could have helped me a lot with a project some years ago, so I took a look at partially implementing #281.

## What's new
The workspace now keeps track of mappings applied to it in an aggregated map conforming to the internal ASM format. This aggregated map can then be used to provide a basic export facility for mappings in that format (the Simple format).

The mapping in the workspace only stores the end result of all applied mappings. That means that rename operations "a -> b -> c" are folded together and stored as "a -> c". To enable this, `AsmMappingUtils` contains code to apply new mapping rules to existing mappings by just operating on the mapping Strings itself rather than a real class graph.

While it would be nice to be able to export to all the supported import formats, this is a start and should be possible to expand on later.

This is a partial implementation of #281

## Implementation Notes
I haven't worked too much with ASM and remapping before, so I hope my very very primitive approach to handling transitive mappings is not fundamentally flawed. Please educate me if it is though! 😄 

There are some especially rough edges when handling constructors, initializers and invokedynamic remapping in `AsmMappingUtils`. Can you point me to a resource or test case to understand these better?
