### PR TITLE
Base abstractions for managing decompiler impls

### DIFF
--- a/recaf-core/src/main/java/me/coley/recaf/Controller.java
+++ b/recaf-core/src/main/java/me/coley/recaf/Controller.java
@@ -9,6 +9,7 @@ import me.coley.recaf.workspace.Workspace;
  * @author Matt Coley
  */
 public class Controller {
+	private final Services services = new Services(this);
 	private final Presentation presentation;
 	private Workspace workspace;
 
@@ -18,6 +19,13 @@ public class Controller {
 	 */
 	public Controller(Presentation presentation) {
 		this.presentation = presentation;
+	}
+
+	/**
+	 * @return Controller services.
+	 */
+	public Services getServices() {
+		return services;
 	}
 
 	/**

--- a/recaf-core/src/main/java/me/coley/recaf/Services.java
+++ b/recaf-core/src/main/java/me/coley/recaf/Services.java
@@ -1,0 +1,30 @@
+package me.coley.recaf;
+
+import me.coley.recaf.decompile.DecompileManager;
+
+/**
+ * Wrapper of multiple services that are provided by a controller.
+ * Placing them in here keeps the actual {@link Controller} class minimal.
+ *
+ * @author Matt Coley
+ */
+public class Services {
+	private final DecompileManager decompileManager;
+
+	/**
+	 * Initialize services.
+	 *
+	 * @param controller
+	 * 		Parent controller instance.
+	 */
+	Services(Controller controller) {
+		decompileManager = new DecompileManager();
+	}
+
+	/**
+	 * @return The decompiler manager.
+	 */
+	public DecompileManager getDecompileManager() {
+		return decompileManager;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileManager.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileManager.java
@@ -1,0 +1,44 @@
+package me.coley.recaf.decompile;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Manager of decompilers.
+ *
+ * @author Matt Coley
+ */
+// TODO: Supply this with @Inject or put it in Controller?
+//   - If @Inject, must integrate a DI system, but then any user just needs to ask for the types they depend on.
+//   - If put in Controller, simple, but similar services also would be put there. Can get bloated if repeated often.
+public class DecompileManager {
+	private final Map<String, Decompiler> decompilerMap = new TreeMap<>();
+
+	/**
+	 * Add a decompiler to the manager.
+	 *
+	 * @param decompiler
+	 * 		Decompiler implementation.
+	 */
+	public void register(Decompiler decompiler) {
+		this.decompilerMap.put(decompiler.getName(), decompiler);
+	}
+
+	/**
+	 * @param name
+	 * 		Name of the decompiler, see {@link Decompiler#getName()}.
+	 *
+	 * @return Instance of decompiler.
+	 */
+	public Decompiler get(String name) {
+		return decompilerMap.get(name);
+	}
+
+	/**
+	 * @return Collection of all registered decompilers.
+	 */
+	public Collection<Decompiler> getRegisteredDecompilers() {
+		return decompilerMap.values();
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileManager.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileManager.java
@@ -9,9 +9,6 @@ import java.util.TreeMap;
  *
  * @author Matt Coley
  */
-// TODO: Supply this with @Inject or put it in Controller?
-//   - If @Inject, must integrate a DI system, but then any user just needs to ask for the types they depend on.
-//   - If put in Controller, simple, but similar services also would be put there. Can get bloated if repeated often.
 public class DecompileManager {
 	private final Map<String, Decompiler> decompilerMap = new TreeMap<>();
 

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileOption.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileOption.java
@@ -1,0 +1,86 @@
+package me.coley.recaf.decompile;
+
+/**
+ * Wrapper for decompiler options so each decompiler option set is not handled specifically based on implementation.
+ *
+ * @param <T>
+ * 		Option type. Exposed as {@link #getValueType()}.
+ *
+ * @author Matt Coley
+ */
+public class DecompileOption<T> {
+	private final Class<T> valueType;
+	private final String optionName;
+	private final String recafNameAlias;
+	private final String description;
+	private final T defaultValue;
+
+	/**
+	 * @param valueType
+	 * 		Type of supported values.
+	 * @param optionName
+	 * 		Option name as defined by the decompiler.
+	 * @param description
+	 * 		Description of what the option controls in the decompiler output.
+	 * @param defaultValue
+	 * 		Default value for the option.
+	 */
+	public DecompileOption(Class<T> valueType, String optionName, String description, T defaultValue) {
+		this(valueType, optionName, optionName, description, defaultValue);
+	}
+
+	/**
+	 * @param valueType
+	 * 		Type of supported values.
+	 * @param optionName
+	 * 		Option name as defined by the decompiler.
+	 * @param recafNameAlias
+	 * 		Alias for the option name, used by Recaf to consolidate the <i>"same"</i> feature across different decompiler implementations.
+	 * @param description
+	 * 		Description of what the option controls in the decompiler output.
+	 * @param defaultValue
+	 * 		Default value for the option.
+	 */
+	public DecompileOption(Class<T> valueType, String optionName, String recafNameAlias, String description, T defaultValue) {
+		this.valueType = valueType;
+		this.optionName = optionName;
+		this.recafNameAlias = recafNameAlias;
+		this.description = description;
+		this.defaultValue = defaultValue;
+	}
+
+	/**
+	 * @return Type of supported values.
+	 */
+	public Class<T> getValueType() {
+		return valueType;
+	}
+
+	/**
+	 * @return Option name as defined by the decompiler.
+	 */
+	public String getOptionName() {
+		return optionName;
+	}
+
+	/**
+	 * @return Alias for the option name, used by Recaf to consolidate the <i>"same"</i> feature across different decompiler implementations.
+	 */
+	public String getRecafNameAlias() {
+		return recafNameAlias;
+	}
+
+	/**
+	 * @return Description of what the option controls in the decompiler output.
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * @return Default value for the option.
+	 */
+	public T getDefaultValue() {
+		return defaultValue;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileResult.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/DecompileResult.java
@@ -1,0 +1,83 @@
+package me.coley.recaf.decompile;
+
+import me.coley.recaf.workspace.resource.ClassInfo;
+
+/**
+ * Decompile result wrapper.
+ *
+ * @author Matt Coley
+ */
+public class DecompileResult {
+	private final Decompiler decompiler;
+	private final ClassInfo classInfo;
+	private final String decompiledText;
+	private final Exception exception;
+
+	/**
+	 * @param decompiler
+	 * 		Decompiler responsible for the result.
+	 * @param classInfo
+	 * 		Original class information of the decompile result.
+	 * @param decompiledText
+	 * 		Decompiled code of the class.
+	 */
+	public DecompileResult(Decompiler decompiler, ClassInfo classInfo, String decompiledText) {
+		this(decompiler, classInfo, decompiledText, null);
+	}
+
+	/**
+	 * @param decompiler
+	 * 		Decompiler responsible for the result.
+	 * @param classInfo
+	 * 		Original class information of the decompile result.
+	 * @param exception
+	 * 		Exception thrown when attempting to decompile.
+	 */
+	public DecompileResult(Decompiler decompiler, ClassInfo classInfo, Exception exception) {
+		this(decompiler, classInfo, null, exception);
+	}
+
+	private DecompileResult(Decompiler decompiler, ClassInfo classInfo, String decompiledText, Exception exception) {
+		this.decompiler = decompiler;
+		this.classInfo = classInfo;
+		this.decompiledText = decompiledText;
+		this.exception = exception;
+	}
+
+	/**
+	 * Indicates if the result contains either a {@link #getDecompiledText() text output} or {@link #getException() error}.
+	 *
+	 * @return {@code true} if {@link #getDecompiledText()}
+	 */
+	public boolean wasSuccess() {
+		return exception != null;
+	}
+
+	/**
+	 * @return Decompiler responsible for the result.
+	 */
+	public Decompiler getDecompiler() {
+		return decompiler;
+	}
+
+	/**
+	 * @return Original class information of the decompile result.
+	 */
+	public ClassInfo getClassInfo() {
+		return classInfo;
+	}
+
+	/**
+	 * @return Decompiled code. May be {@code null} if an {@link #getException() error} occurred when decompiling.
+	 */
+	public String getDecompiledText() {
+		return decompiledText;
+	}
+
+	/**
+	 * @return Error thrown when attempting to decompile. May be {@code null} if decompile was a success.
+	 */
+	public Exception getException() {
+		return exception;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/Decompiler.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/Decompiler.java
@@ -1,0 +1,121 @@
+package me.coley.recaf.decompile;
+
+import me.coley.recaf.workspace.Workspace;
+import me.coley.recaf.workspace.resource.ClassInfo;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Decompiler wrapper.
+ *
+ * @author Matt Coley
+ */
+public abstract class Decompiler implements Comparable<Decompiler> {
+	private final Map<String, DecompileOption<?>> defaultOptions = createDefaultOptions();
+	private final String name;
+	private final String version;
+
+	protected Decompiler(String name, String version) {
+		this.name = name;
+		this.version = version;
+	}
+
+	/**
+	 * @return Decompiler name.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @return Decompiler version.
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * @return Map of default options used by the decompiler.
+	 */
+	public Map<String, DecompileOption<?>> getDefaultOptions() {
+		return defaultOptions;
+	}
+
+	/**
+	 * Decompile a class, using default options.
+	 *
+	 * @param workspace
+	 * 		Workspace to supply additional classes for reference.
+	 * 		Can be {@code null} at the cost of accuracy depending on the decompiler implementation.
+	 * @param classInfo
+	 * 		Class to decompile.
+	 *
+	 * @return Result from decompilation.
+	 * Wraps either the code decompiled or the error information that prevented decompilation.
+	 */
+	public DecompileResult decompile(Workspace workspace, ClassInfo classInfo) {
+		return decompile(getDefaultOptions(), workspace, classInfo);
+	}
+
+	/**
+	 * Decompile a class.
+	 *
+	 * @param options
+	 * 		Decompiler options.
+	 * @param workspace
+	 * 		Workspace to supply additional classes for reference.
+	 * 		Can be {@code null} at the cost of accuracy depending on the decompiler implementation.
+	 * @param classInfo
+	 * 		Class to decompile.
+	 *
+	 * @return Result from decompilation.
+	 * Wraps either the code decompiled or the error information that prevented decompilation.
+	 */
+	public DecompileResult decompile(Map<String, DecompileOption<?>> options, Workspace workspace, ClassInfo classInfo) {
+		try {
+			return new DecompileResult(this, classInfo, decompileImpl(options, workspace, classInfo));
+		} catch (Exception ex) {
+			return new DecompileResult(this, classInfo, ex);
+		}
+	}
+
+	/**
+	 * Internal decompile call that will be implemented by implementations.
+	 *
+	 * @param options
+	 * 		Decompiler options.
+	 * @param workspace
+	 * 		Workspace to pull additional classes if the implementation needs to reference separate classes.
+	 * 		May be {@code null}.
+	 * @param classInfo
+	 * 		Class to decompile.
+	 *
+	 * @return Decompiled code of a class.
+	 */
+	protected abstract String decompileImpl(Map<String, DecompileOption<?>> options, Workspace workspace, ClassInfo classInfo);
+
+	/**
+	 * @return Map of options used by the decompiler as a default.
+	 */
+	protected abstract Map<String, DecompileOption<?>> createDefaultOptions();
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof Decompiler)) return false;
+		Decompiler that = (Decompiler) o;
+		return name.equals(that.name) &&
+				version.equals(that.version);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, version);
+	}
+
+	@Override
+	public int compareTo(Decompiler o) {
+		return getName().compareTo(o.getName());
+	}
+}


### PR DESCRIPTION
## What's new

* Outline for decompiler implementations
* Decompile manager that will allow 3rd parties to register their own decompilers

The goal is to abstract away references to decompilers via `DecompileManager` so that plugins can add their own decompilers and it should just integrate seamlessly.