### PR TITLE
Javac target fix

### DIFF
--- a/src/main/java/me/coley/recaf/compiler/JavacTargetVersion.java
+++ b/src/main/java/me/coley/recaf/compiler/JavacTargetVersion.java
@@ -88,7 +88,7 @@ public enum JavacTargetVersion {
 		} catch (Exception ex) {
 			Log.error("Failed to find javac maximum supported version, defaulting to Java 8 (52)");
 		}
-		return V7;
+		return V8;
 	}
 
 	@Override

--- a/src/main/java/me/coley/recaf/ui/controls/text/JavaEditorPane.java
+++ b/src/main/java/me/coley/recaf/ui/controls/text/JavaEditorPane.java
@@ -122,7 +122,7 @@ public class JavaEditorPane extends EditorPane<JavaErrorHandling, JavaContextHan
 		JavacTargetVersion maxSupportedVersion = JavacTargetVersion.getMaxJavacSupport();
 		if (minSupportedVersion.ordinal() > classVersion.ordinal())
 			classVersion = minSupportedVersion;
-		if (maxSupportedVersion.ordinal() > classVersion.ordinal())
+		if (maxSupportedVersion.ordinal() < classVersion.ordinal())
 			classVersion = maxSupportedVersion;
 		javac.options().setTarget(classVersion);
 		javac.setCompileListener(getErrorHandler());


### PR DESCRIPTION
## What's fixed

* I noticed that comparation of class version and max supported target version was wrong, resulting in that version of the target class version would always become the highest version supported by javac. In my case the original class was v7 but when I edited it would be compiled as v8 which was not correct and caused an issue as the resulting jar was to be run by a version 1.7 jvm.
*  Small fix for default of max target version, the log message and the returned version were not consistent.