### PR TITLE
fix: Unknown cli argument crashes application

### DIFF
--- a/src/main/java/me/coley/recaf/Recaf.java
+++ b/src/main/java/me/coley/recaf/Recaf.java
@@ -94,7 +94,11 @@ public class Recaf {
 	private static void launch(String[] args) {
 		// Setup initializer, this loads command line arguments
 		Initializer initializer = new Initializer();
-		new CommandLine(initializer).execute(args);
+		CommandLine commandLine = new CommandLine(initializer);
+		commandLine.execute(args);
+		if (commandLine.getUnmatchedArguments().size() > 0)
+			return;
+
 		headless = initializer.cli;
 		loadPlugins();
 		// Do version check


### PR DESCRIPTION
## What's fixed

Fixes #313.
Just returning seems to be the best option for me. picocli prints a nice help message anyway.
Another option would be to set `CommandLine#setUnmatchedArgumentsAllowed` to true, but this would make spotting typos harder.
