### PR TITLE
3X: Add javac compiler implementation

### DIFF
--- a/recaf-core/build.gradle
+++ b/recaf-core/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation asm_tree
     implementation asm_util
     implementation common_io
+    implementation directories
     implementation logback_classic
     implementation guava
 

--- a/recaf-core/src/main/java/me/coley/recaf/compile/CompilerDiagnostic.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/CompilerDiagnostic.java
@@ -1,0 +1,36 @@
+package me.coley.recaf.compile;
+
+/**
+ * Simple compiler feedback wrapper.
+ *
+ * @author Matt Coley
+ */
+public class CompilerDiagnostic {
+	private final int line;
+	private final String message;
+
+	/**
+	 * @param line
+	 * 		Line the message applies to.
+	 * @param message
+	 * 		Message detailing the problem.
+	 */
+	public CompilerDiagnostic(int line, String message) {
+		this.line = line;
+		this.message = message;
+	}
+
+	/**
+	 * @return Line the message applies to.
+	 */
+	public int getLine() {
+		return line;
+	}
+
+	/**
+	 * @return Message detailing the problem.
+	 */
+	public String getMessage() {
+		return message;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/compile/CompilerResult.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/CompilerResult.java
@@ -2,12 +2,16 @@ package me.coley.recaf.compile;
 
 import me.coley.recaf.plugin.tools.ToolResult;
 
+import java.util.List;
+
 /**
  * Compilation result wrapper.
  *
  * @author Matt Coley
  */
 public class CompilerResult extends ToolResult<Compiler, CompileMap> {
+	private final List<CompilerDiagnostic> errors;
+
 	/**
 	 * Result with class compilations.
 	 *
@@ -17,7 +21,19 @@ public class CompilerResult extends ToolResult<Compiler, CompileMap> {
 	 * 		Resulting compiled classes.
 	 */
 	public CompilerResult(Compiler compiler, CompileMap compilations) {
-		super(compiler, compilations, null);
+		this(compiler, compilations, null, null);
+	}
+
+	/**
+	 * Result where compiler fails due to errors in the source.
+	 *
+	 * @param compiler
+	 * 		Compiler responsible for the compilation map.
+	 * @param errors
+	 * 		Exception thrown when attempting to compile.
+	 */
+	public CompilerResult(Compiler compiler, List<CompilerDiagnostic> errors) {
+		this(compiler, null, null, errors);
 	}
 
 	/**
@@ -29,9 +45,19 @@ public class CompilerResult extends ToolResult<Compiler, CompileMap> {
 	 * 		Exception thrown when attempting to compile.
 	 */
 	public CompilerResult(Compiler compiler, Throwable exception) {
-		super(compiler, null, exception);
-		// TODO: Compilers may emit multiple outputs,
-		//    it would be wise to bundle them in a custom exception type
-		//    to conform to the ToolResult layout
+		this(compiler, null, exception, null);
+	}
+
+	private CompilerResult(Compiler compiler, CompileMap compilations, Throwable exception,
+						   List<CompilerDiagnostic> errors) {
+		super(compiler, compilations, exception);
+		this.errors = errors;
+	}
+
+	/**
+	 * @return Compiler diagnostic outputs when the source contains errors.
+	 */
+	public List<CompilerDiagnostic> getErrors() {
+		return errors;
 	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/compile/javac/ForwardingListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/javac/ForwardingListener.java
@@ -1,0 +1,25 @@
+package me.coley.recaf.compile.javac;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+
+/**
+ * Diagnostic listener that forwards reports to a delegate listener.
+ *
+ * @author Matt Coley
+ */
+public class ForwardingListener implements JavacListener {
+	private final JavacListener delegate;
+
+	ForwardingListener(JavacListener delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
+		if (delegate != null)
+		{
+			delegate.report(diagnostic);
+		}
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/compile/javac/JavacCompiler.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/javac/JavacCompiler.java
@@ -1,0 +1,145 @@
+package me.coley.recaf.compile.javac;
+
+import me.coley.recaf.compile.CompileOption;
+import me.coley.recaf.compile.Compiler;
+import me.coley.recaf.compile.CompilerResult;
+import me.coley.recaf.util.JavaVersion;
+import me.coley.recaf.util.logging.Logging;
+import me.coley.recaf.util.Directories;
+import org.slf4j.Logger;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Wrapper for {@link JavaCompiler}.
+ *
+ * @author Matt Coley
+ */
+public class JavacCompiler extends Compiler {
+	private static final Logger logger = Logging.get(JavacCompiler.class);
+	private static final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+	private JavacListener listener;
+
+	/**
+	 * New javac compiler wrapper.
+	 */
+	public JavacCompiler() {
+		super("javac", System.getProperty("java.version"));
+	}
+
+	@Override
+	public CompilerResult compile(String className, String classSource, Map<String, CompileOption<?>> options) {
+		// Class input map
+		VirtualUnitMap unitMap = new VirtualUnitMap();
+		unitMap.addSource(className, classSource);
+		// Create a file manager to track files in-memory rather than on-disk
+		JavaFileManager fmFallback = compiler.getStandardFileManager(listener, Locale.getDefault(), UTF_8);
+		JavaFileManager fm = new VirtualFileManager(unitMap, fmFallback);
+		// Populate arguments
+		//  - Classpath
+		//  - Target bytecode level
+		//  - Debug info
+		List<String> args = new ArrayList<>();
+		if (options.containsKey("classpath")) {
+			String cp = options.get("classpath").getValue().toString();
+			args.add("-classpath");
+			args.add(cp);
+			logger.debug("Compiler classpath: {}", cp);
+		}
+		if (options.containsKey("target")) {
+			String target = options.get("target").getValue().toString();
+			if (JavaVersion.get() > 8) {
+				args.add("--release");
+				args.add(target);
+			} else {
+				args.add("-source");
+				args.add(target);
+				args.add("-target");
+				args.add(target);
+			}
+			logger.debug("Compiler target: {}", target);
+		}
+		if (options.containsKey("debug")) {
+			String value = options.get("debug").getValue().toString();
+			if (value.isEmpty())
+				value = "none";
+			args.add("-g:" + value);
+			logger.debug("Compiler debug: {}", value);
+		} else {
+			args.add("-g:none");
+			logger.debug("Compiler debug: none");
+		}
+		// Invoke compiler
+		try {
+			JavaCompiler.CompilationTask task = compiler.getTask(null, fm, listener, args, null, unitMap.getFiles());
+			if (task.call()) {
+				logger.info("Compilation of '{}' finished", className);
+				return new CompilerResult(this, unitMap.getCompilations());
+			} else {
+				logger.error("Compilation of '{}' failed", className);
+				return new CompilerResult(this, new IllegalStateException("Invoking javac failed!"));
+			}
+		} catch(RuntimeException ex) {
+			logger.error("Compilation of '{}' crashed: {}", className, ex);
+			return new CompilerResult(this, ex);
+		}
+	}
+
+	@Override
+	protected Map<String, CompileOption<?>> createDefaultOptions() {
+		// TODO: Replace descriptions with translations
+		//  - How do we want to handle translation usage in the core?
+		//    Typically this would be a UI-only thing
+		//  - Do we even want to support things like this?
+		//    Would support here make the system less maintainable?
+		Map<String, CompileOption<?>> options = new HashMap<>();
+		options.put("target",
+				new CompileOption<>(int.class, "--release", "target", "Target Java version", 8));
+		options.put("debug",
+				new CompileOption<>(String.class, "-g", "debug", "Debug information", "vars,lines,source"));
+		options.put("classpath",
+				new CompileOption<>(String.class, "-cp", "classpath", "Classpath", createClassPath()));
+		return options;
+	}
+
+
+	/**
+	 * @return Generated classpath.
+	 */
+	private String createClassPath() {
+		// Ensure the default path is included
+		String pathDefault = System.getProperty("java.class.path");
+		StringBuilder sb = new StringBuilder(pathDefault);
+		char separator = File.pathSeparatorChar;
+		// Add classpath extension directory
+		// Add phantoms directory
+		try {
+			Stream<Path> classpathJars = Files.walk(Directories.getClasspathDirectory());
+			Stream<Path> phantomJars = Files.walk(Directories.getPhantomsDirectory());
+			Stream.concat(classpathJars, phantomJars)
+					.filter(p -> p.toString().toLowerCase().endsWith(".jar"))
+					.forEach(p -> sb.append(separator).append(p.toAbsolutePath().toString()));
+		} catch (IOException ex) {
+			ex.printStackTrace();
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * @param listener
+	 * 		Listener that receives compiler error information.
+	 */
+	public void setCompileListener(JavacListener listener) {
+		this.listener = listener;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/compile/javac/JavacListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/javac/JavacListener.java
@@ -1,0 +1,11 @@
+package me.coley.recaf.compile.javac;
+
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaFileObject;
+
+/**
+ * Diagnostic list wrapper.
+ *
+ * @author Matt Coley
+ */
+public interface JavacListener extends DiagnosticListener<JavaFileObject> {}

--- a/recaf-core/src/main/java/me/coley/recaf/compile/javac/VirtualFileManager.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/javac/VirtualFileManager.java
@@ -1,0 +1,43 @@
+package me.coley.recaf.compile.javac;
+
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+
+/**
+ * File manager extension for handling updates to java file object's output stream.
+ * Additionally, registers inner classes as new files.
+ *
+ * @author Matt Coley
+ */
+public class VirtualFileManager extends ForwardingJavaFileManager<JavaFileManager> {
+	private final VirtualUnitMap unitMap;
+
+	/**
+	 * @param unitMap
+	 * 		Class input map.
+	 * @param fallback
+	 * 		Fallback manager.
+	 */
+	public VirtualFileManager(VirtualUnitMap unitMap, JavaFileManager fallback) {
+		super(fallback);
+		this.unitMap = unitMap;
+	}
+
+	@Override
+	public JavaFileObject getJavaFileForOutput(JavaFileManager.Location location, String name, JavaFileObject.Kind
+			kind, FileObject sibling) throws IOException {
+		String internal = name.replace('.', '/');
+		VirtualJavaFileObject obj = unitMap.getFile(internal);
+		// Unknown class, assumed to be an inner class.
+		// add to the unit map so it can be fetched.
+		if (obj == null) {
+			// TODO: Double check that it uses "Outer$Inner" pattern instead of "Outer.Inner"
+			obj = new VirtualJavaFileObject(internal, null);
+			unitMap.addFile(internal, obj);
+		}
+		return obj;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/compile/javac/VirtualJavaFileObject.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/javac/VirtualJavaFileObject.java
@@ -1,0 +1,57 @@
+package me.coley.recaf.compile.javac;
+
+import javax.tools.SimpleJavaFileObject;
+import java.io.*;
+import java.net.URI;
+
+/**
+ * Java file extension that keeps track of the compiled bytecode.
+ *
+ * @author Matt Coley
+ */
+public class VirtualJavaFileObject extends SimpleJavaFileObject {
+	/**
+	 * Output to contain compiled bytcode.
+	 */
+	private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+	/**
+	 * Content of source file to compile.
+	 */
+	private final String content;
+
+	/**
+	 * @param className
+	 * 		Name of class.
+	 * @param content
+	 * 		Class source content.
+	 */
+	public VirtualJavaFileObject(String className, String content) {
+		super(URI.create("string:///" + className.replace('.', '/') + Kind.SOURCE.extension),
+				Kind.SOURCE);
+		this.content = content;
+	}
+
+	/**
+	 * @return Compiled bytecode of class.
+	 */
+	public byte[] getBytecode() {
+		return baos.toByteArray();
+	}
+
+	/**
+	 * @return Class source code.
+	 */
+	public String getSource() {
+		return content;
+	}
+
+	@Override
+	public final OutputStream openOutputStream() throws IOException {
+		return baos;
+	}
+
+	@Override
+	public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+		return content;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/compile/javac/VirtualUnitMap.java
+++ b/recaf-core/src/main/java/me/coley/recaf/compile/javac/VirtualUnitMap.java
@@ -1,0 +1,80 @@
+package me.coley.recaf.compile.javac;
+
+import me.coley.recaf.compile.CompileMap;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * {@link javax.tools.JavaFileObject} map wrapper for managing class inputs for the compiler.
+ *
+ * @author Matt Coley
+ */
+public class VirtualUnitMap {
+	private final Map<String, VirtualJavaFileObject> unitMap = new HashMap<>();
+
+	/**
+	 * Add class to compilation process.
+	 *
+	 * @param className
+	 * 		Name of class to compile.
+	 * @param content
+	 * 		Source code of class.
+	 */
+	public void addSource(String className, String content) {
+		addFile(className, new VirtualJavaFileObject(className, content));
+	}
+
+	/**
+	 * Add class to compilation process.
+	 *
+	 * @param className
+	 * 		Name of class to compile.
+	 * @param fileObject
+	 * 		File object for source code of class.
+	 */
+	public void addFile(String className, VirtualJavaFileObject fileObject) {
+		unitMap.put(className, fileObject);
+	}
+
+	/**
+	 * @param className
+	 * 		Name of class.
+	 *
+	 * @return File object for source code of class.
+	 */
+	public VirtualJavaFileObject getFile(String className) {
+		return unitMap.get(className);
+	}
+
+	/**
+	 * @return Collection of file objects for input classes.
+	 */
+	public Collection<VirtualJavaFileObject> getFiles() {
+		return unitMap.values();
+	}
+
+	/**
+	 * @param name
+	 * 		Class name.
+	 *
+	 * @return Bytecode of class.
+	 */
+	public byte[] getCompilation(String name) {
+		VirtualJavaFileObject file = unitMap.get(name);
+		if (file == null)
+			return null;
+		return file.getBytecode();
+	}
+
+	/**
+	 * @return Map of class names to bytecode.
+	 */
+	public CompileMap getCompilations() {
+		Map<String, byte[]> map = unitMap.entrySet().stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().getBytecode()));
+		return new CompileMap(map);
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/plugin/tools/Tool.java
+++ b/recaf-core/src/main/java/me/coley/recaf/plugin/tools/Tool.java
@@ -1,5 +1,6 @@
 package me.coley.recaf.plugin.tools;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -39,10 +40,10 @@ public abstract class Tool<T extends ToolOption<?>> implements Comparable<Tool<?
 	}
 
 	/**
-	 * @return Map of default options used by the tool.
+	 * @return Copy of default options used by the tool.
 	 */
 	public Map<String, T> getDefaultOptions() {
-		return defaultOptions;
+		return new HashMap<>(defaultOptions);
 	}
 
 	/**

--- a/recaf-core/src/main/java/me/coley/recaf/util/Directories.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/Directories.java
@@ -1,7 +1,11 @@
 package me.coley.recaf.util;
 
 import dev.dirs.BaseDirectories;
+import me.coley.recaf.util.logging.Logging;
+import org.slf4j.Logger;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -11,6 +15,7 @@ import java.nio.file.Paths;
  * @author Matt Coley
  */
 public class Directories {
+	private static final Logger logger = Logging.get(Directories.class);
 	private static final Path baseDirectory = createBaseDirectory();
 	private static final Path classpathDirectory = baseDirectory.resolve("classpath");
 	private static final Path configDirectory = baseDirectory.resolve("config");
@@ -95,6 +100,19 @@ public class Directories {
 			} else {
 				throw new IllegalStateException("Failed to initialize Recaf directory");
 			}
+		}
+	}
+
+	static {
+		try {
+			Files.createDirectories(classpathDirectory);
+			Files.createDirectories(configDirectory);
+			Files.createDirectories(dependenciesDirectory);
+			Files.createDirectories(phantomsDirectory);
+			Files.createDirectories(pluginDirectory);
+			Files.createDirectories(styleDirectory);
+		} catch (IOException ex) {
+			logger.error("Failed to create Recaf directories", ex);
 		}
 	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/util/Directories.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/Directories.java
@@ -1,0 +1,100 @@
+package me.coley.recaf.util;
+
+import dev.dirs.BaseDirectories;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Common Recaf directories.
+ *
+ * @author Matt Coley
+ */
+public class Directories {
+	private static final Path baseDirectory = createBaseDirectory();
+	private static final Path classpathDirectory = baseDirectory.resolve("classpath");
+	private static final Path configDirectory = baseDirectory.resolve("config");
+	private static final Path dependenciesDirectory = baseDirectory.resolve("dependencies");
+	private static final Path phantomsDirectory = baseDirectory.resolve("phantoms");
+	private static final Path pluginDirectory = baseDirectory.resolve("plugins");
+	private static final Path styleDirectory = baseDirectory.resolve("style");
+
+	/**
+	 * @return Base Recaf directory.
+	 */
+	public static Path getBaseDirectory() {
+		return baseDirectory;
+	}
+
+	/**
+	 * @return Directory where extensions for the compiler classpath are stored.
+	 */
+	public static Path getClasspathDirectory() {
+		// TODO: If we want to save space when "copying" resources into this folder we can
+		//       use ASM to strip out method bodies. Keep debug info for signatures though.
+		//       Can also exclude any non-classes from the jar.
+		//
+		// TODO: Do we want to split this into two subdirs?
+		//        - Jars     - Point to list of contained jars
+		//        - Classes  - Point to root
+		return classpathDirectory;
+	}
+
+	/**
+	 * @return Directory where configuration is stored.
+	 */
+	public static Path getConfigDirectory() {
+		return configDirectory;
+	}
+
+	/**
+	 * @return Directory where additional Recaf dependencies are stored to be injected at runtime.
+	 */
+	public static Path getDependenciesDirectory() {
+		return dependenciesDirectory;
+	}
+
+	/**
+	 * @return Directory where plugins are stored.
+	 */
+	public static Path getPluginDirectory() {
+		// TODO: We can use a "disabled" subfolder to mark a plugin as disabled
+		return pluginDirectory;
+	}
+
+	/**
+	 * @return Directory where generated phantom classes are stored.
+	 */
+	public static Path getPhantomsDirectory() {
+		// TODO: Allow an opt-in feature where phantom classes are not deleted.
+		//  - Means if you re-open the same resource, it looks for the cached first
+		return phantomsDirectory;
+	}
+
+	/**
+	 * @return Directory where additional stylesheets are stored.
+	 */
+	public static Path getStyleDirectory() {
+		return styleDirectory;
+	}
+
+	private static Path createBaseDirectory() {
+		try {
+			// Windows: %APPDATA%/
+			// Mac:     $HOME/Library/Application Support/
+			// Linux:   $XDG_CONFIG_HOME/   or   $HOME/.config
+			String dir = BaseDirectories.get().configDir;
+			if (dir == null)
+				throw new NullPointerException("BaseDirectories did not yield an initial directory");
+			return Paths.get(dir).resolve("Recaf");
+		} catch (Throwable t) {
+			// The lookup only seems to fail on windows.
+			// And we can lookup the APPDATA folder easily.
+			if (OperatingSystem.get() == OperatingSystem.WINDOWS) {
+				return Paths.get(System.getenv("APPDATA"), "Recaf");
+			} else {
+				throw new IllegalStateException("Failed to initialize Recaf directory");
+			}
+		}
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/util/JavaVersion.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/JavaVersion.java
@@ -1,0 +1,51 @@
+package me.coley.recaf.util;
+
+import me.coley.recaf.util.logging.Logging;
+import org.slf4j.Logger;
+
+/**
+ * Supported Java version of the current JVM.
+ *
+ * @author Matt Coley
+ */
+public class JavaVersion {
+	/**
+	 * The offset from which a version and the version constant value is. For example, Java 8 is 52 <i>(44 + 8)</i>.
+	 */
+	public static final int VERSION_OFFSET = 44;
+	private static final String JAVA_CLASS_VERSION = "java.class.version";
+	private static final String JAVA_VM_SPEC_VERSION = "java.vm.specification.version";
+	private static final int FALLBACK_VERSION = 8;
+	private static final Logger logger = Logging.get(JavaVersion.class);
+	private static int version = -1;
+
+	/**
+	 * Get the supported Java version of the current JVM.
+	 *
+	 * @return Version.
+	 */
+	public static int get() {
+		if (version < 0) {
+			// Check for class version
+			String property = System.getProperty(JAVA_CLASS_VERSION, "");
+			if (!property.isEmpty())
+				return version = (int) (Float.parseFloat(property) - VERSION_OFFSET);
+			// Odd, not found. Try the spec version
+			logger.warn("Property '{}' not found, using '{}' as fallback",
+					JAVA_CLASS_VERSION,
+					JAVA_VM_SPEC_VERSION
+			);
+			property = System.getProperty(JAVA_VM_SPEC_VERSION, "");
+			if (property.contains("."))
+				return version = (int) Float.parseFloat(property.substring(property.indexOf('.') + 1));
+			else if (!property.isEmpty())
+				return version = Integer.parseInt(property);
+			logger.warn("Property '{}' not found, using '{}' as fallback",
+					JAVA_VM_SPEC_VERSION, FALLBACK_VERSION
+			);
+			// Very odd
+			return FALLBACK_VERSION;
+		}
+		return version;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/util/OperatingSystem.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/OperatingSystem.java
@@ -1,0 +1,41 @@
+package me.coley.recaf.util;
+
+/**
+ * Operating system enumeration.
+ *
+ * @author Matt Coley
+ */
+public enum OperatingSystem {
+	WINDOWS("win"),
+	MAC("mac"),
+	LINUX("linux");
+
+	private final String mvnName;
+
+	OperatingSystem(String mvnName) {
+		this.mvnName = mvnName;
+	}
+
+	/**
+	 * In some cases, maven artifacts with natives will be published with os-specific suffixes.
+	 *
+	 * @return Maven artifact name suffix.
+	 */
+	public String getMvnName() {
+		return mvnName;
+	}
+
+	/**
+	 * @return Operating system short-hand name.
+	 */
+	public static OperatingSystem get() {
+		String s = System.getProperty("os.name").toLowerCase();
+		if (s.contains("win")) {
+			return WINDOWS;
+		}
+		if (s.contains("mac") || s.contains("osx")) {
+			return MAC;
+		}
+		return LINUX;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/util/logging/InterceptingLogger.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/logging/InterceptingLogger.java
@@ -1,0 +1,394 @@
+package me.coley.recaf.util.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.event.Level;
+
+import java.util.regex.Matcher;
+
+/**
+ * A forwarding logger that lets us intercept compiled messages.
+ *
+ * @author Matt Coley
+ */
+public abstract class InterceptingLogger implements Logger {
+	private final Logger backing;
+
+	/**
+	 * @param backing
+	 * 		Backing logger to send info to.
+	 */
+	protected InterceptingLogger(Logger backing) {
+		this.backing = backing;
+	}
+
+	/**
+	 * Intercept logging.
+	 *
+	 * @param level
+	 * 		Level logged.
+	 * @param message
+	 * 		Message logged.
+	 */
+	public abstract void log(Level level, String message);
+
+	/**
+	 * Intercept throwable logging.
+	 *
+	 * @param level
+	 * 		Level logged.
+	 * @param t
+	 * 		Item thrown.
+	 */
+	public abstract void log(Level level, Throwable t);
+
+	@Override
+	public String getName() {
+		return backing.getName();
+	}
+
+	@Override
+	public boolean isTraceEnabled() {
+		return backing.isTraceEnabled();
+	}
+
+	@Override
+	public boolean isTraceEnabled(Marker marker) {
+		return backing.isTraceEnabled(marker);
+	}
+
+	@Override
+	public void trace(String msg) {
+		backing.trace(msg);
+		log(Level.TRACE, msg);
+	}
+
+	@Override
+	public void trace(String format, Object arg) {
+		trace(format, (Object[]) arg);
+	}
+
+	@Override
+	public void trace(String format, Object arg1, Object arg2) {
+		trace(format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void trace(String format, Object... arguments) {
+		backing.trace(format, compile(format, arguments));
+		log(Level.TRACE, compile(format, arguments));
+	}
+
+	@Override
+	public void trace(String msg, Throwable t) {
+		backing.trace(msg, t);
+		log(Level.TRACE, t);
+	}
+
+	@Override
+	public void trace(Marker marker, String msg) {
+		backing.trace(marker, msg);
+		log(Level.TRACE, msg);
+	}
+
+	@Override
+	public void trace(Marker marker, String format, Object arg) {
+		trace(marker, format, (Object[]) arg);
+	}
+
+	@Override
+	public void trace(Marker marker, String format, Object arg1, Object arg2) {
+		trace(marker, format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void trace(Marker marker, String format, Object... arguments) {
+		backing.trace(marker, format, arguments);
+		log(Level.TRACE, compile(format, arguments));
+	}
+
+	@Override
+	public void trace(Marker marker, String msg, Throwable t) {
+		backing.trace(marker, msg, t);
+		log(Level.TRACE, t);
+	}
+
+	@Override
+	public boolean isDebugEnabled() {
+		return backing.isDebugEnabled();
+	}
+
+	@Override
+	public boolean isDebugEnabled(Marker marker) {
+		return backing.isDebugEnabled(marker);
+	}
+
+	@Override
+	public void debug(String msg) {
+		backing.debug(msg);
+		log(Level.DEBUG, msg);
+	}
+
+	@Override
+	public void debug(String format, Object arg) {
+		debug(format, (Object[]) arg);
+	}
+
+	@Override
+	public void debug(String format, Object arg1, Object arg2) {
+		debug(format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void debug(String format, Object... arguments) {
+		backing.debug(format, arguments);
+		log(Level.DEBUG, compile(format, arguments));
+	}
+
+	@Override
+	public void debug(String msg, Throwable t) {
+		backing.debug(msg, t);
+		log(Level.DEBUG, t);
+	}
+
+	@Override
+	public void debug(Marker marker, String msg) {
+		backing.debug(marker, msg);
+		log(Level.DEBUG, msg);
+	}
+
+	@Override
+	public void debug(Marker marker, String format, Object arg) {
+		debug(marker, format, (Object[]) arg);
+	}
+
+	@Override
+	public void debug(Marker marker, String format, Object arg1, Object arg2) {
+		debug(marker, format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void debug(Marker marker, String format, Object... arguments) {
+		backing.debug(marker, format, arguments);
+		log(Level.DEBUG, compile(format, arguments));
+	}
+
+	@Override
+	public void debug(Marker marker, String msg, Throwable t) {
+		backing.debug(marker, msg, t);
+		log(Level.DEBUG, t);
+	}
+
+	@Override
+	public boolean isInfoEnabled() {
+		return backing.isInfoEnabled();
+	}
+
+	@Override
+	public boolean isInfoEnabled(Marker marker) {
+		return backing.isInfoEnabled(marker);
+	}
+
+	@Override
+	public void info(String msg) {
+		backing.info(msg);
+		log(Level.INFO, msg);
+	}
+
+	@Override
+	public void info(String format, Object arg) {
+		info(format, (Object[]) arg);
+	}
+
+	@Override
+	public void info(String format, Object arg1, Object arg2) {
+		info(format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void info(String format, Object... arguments) {
+		backing.info(format, arguments);
+		log(Level.INFO, compile(format, arguments));
+	}
+
+	@Override
+	public void info(String msg, Throwable t) {
+		backing.info(msg, t);
+		log(Level.INFO, t);
+	}
+
+	@Override
+	public void info(Marker marker, String msg) {
+		backing.info(marker, msg);
+		log(Level.INFO, msg);
+	}
+
+	@Override
+	public void info(Marker marker, String format, Object arg) {
+		info(marker, format, (Object[]) arg);
+	}
+
+	@Override
+	public void info(Marker marker, String format, Object arg1, Object arg2) {
+		info(marker, format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void info(Marker marker, String format, Object... arguments) {
+		backing.info(marker, format, arguments);
+		log(Level.INFO, compile(format, arguments));
+	}
+
+	@Override
+	public void info(Marker marker, String msg, Throwable t) {
+		backing.info(marker, msg, t);
+		log(Level.INFO, t);
+	}
+
+	@Override
+	public boolean isWarnEnabled() {
+		return backing.isWarnEnabled();
+	}
+
+	@Override
+	public boolean isWarnEnabled(Marker marker) {
+		return backing.isWarnEnabled(marker);
+	}
+
+	@Override
+	public void warn(String msg) {
+		backing.warn(msg);
+		log(Level.WARN, msg);
+	}
+
+	@Override
+	public void warn(String format, Object arg) {
+		warn(format, (Object[]) arg);
+	}
+
+	@Override
+	public void warn(String format, Object arg1, Object arg2) {
+		warn(format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void warn(String format, Object... arguments) {
+		backing.warn(format, arguments);
+		log(Level.WARN, compile(format, arguments));
+	}
+
+	@Override
+	public void warn(String msg, Throwable t) {
+		backing.warn(msg, t);
+		log(Level.WARN, t);
+	}
+
+	@Override
+	public void warn(Marker marker, String msg) {
+		backing.warn(marker, msg);
+		log(Level.WARN, msg);
+	}
+
+	@Override
+	public void warn(Marker marker, String format, Object arg) {
+		warn(marker, format, (Object[]) arg);
+	}
+
+	@Override
+	public void warn(Marker marker, String format, Object arg1, Object arg2) {
+		warn(marker, format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void warn(Marker marker, String format, Object... arguments) {
+		backing.warn(marker, format, arguments);
+		log(Level.WARN, compile(format, arguments));
+	}
+
+	@Override
+	public void warn(Marker marker, String msg, Throwable t) {
+		backing.warn(marker, msg, t);
+		log(Level.WARN, t);
+	}
+
+	@Override
+	public boolean isErrorEnabled() {
+		return backing.isErrorEnabled();
+	}
+
+	@Override
+	public boolean isErrorEnabled(Marker marker) {
+		return backing.isErrorEnabled(marker);
+	}
+
+	@Override
+	public void error(String msg) {
+		backing.error(msg);
+		log(Level.ERROR, msg);
+	}
+
+	@Override
+	public void error(String format, Object arg) {
+		error(format, (Object[]) arg);
+	}
+
+	@Override
+	public void error(String format, Object arg1, Object arg2) {
+		error(format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void error(String format, Object... arguments) {
+		backing.error(format, arguments);
+		log(Level.ERROR, compile(format, arguments));
+	}
+
+	@Override
+	public void error(String msg, Throwable t) {
+		backing.error(msg, t);
+		log(Level.ERROR, t);
+	}
+
+	@Override
+	public void error(Marker marker, String msg) {
+		backing.error(marker, msg);
+		log(Level.ERROR, msg);
+	}
+
+	@Override
+	public void error(Marker marker, String format, Object arg) {
+		error(marker, format, (Object[]) arg);
+	}
+
+	@Override
+	public void error(Marker marker, String format, Object arg1, Object arg2) {
+		error(marker, format, new Object[]{arg1, arg2});
+	}
+
+	@Override
+	public void error(Marker marker, String format, Object... arguments) {
+		backing.error(marker, format, arguments);
+		log(Level.ERROR, compile(format, arguments));
+	}
+
+	@Override
+	public void error(Marker marker, String msg, Throwable t) {
+		backing.error(marker, msg, t);
+		log(Level.ERROR, t);
+	}
+
+	private static String compile(String message, Object[] arguments) {
+		int i = 0;
+		while (message.contains("{}")) {
+			// Failsafe, shouldn't occur if logging is written correctly
+			if (i == arguments.length)
+				return message;
+			// Replace arg in pattern
+			Object arg = arguments[i];
+			String argStr = arg == null ? "null" : arg.toString();
+			message = message.replaceFirst("\\{}", Matcher.quoteReplacement(argStr));
+			i++;
+		}
+		return message;
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/util/logging/InterceptingLogger.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/logging/InterceptingLogger.java
@@ -65,7 +65,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void trace(String format, Object arg) {
-		trace(format, (Object[]) arg);
+		trace(format, new Object[] { arg });
 	}
 
 	@Override
@@ -93,7 +93,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void trace(Marker marker, String format, Object arg) {
-		trace(marker, format, (Object[]) arg);
+		trace(marker, format, new Object[] { arg });
 	}
 
 	@Override
@@ -131,7 +131,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void debug(String format, Object arg) {
-		debug(format, (Object[]) arg);
+		debug(format, new Object[] { arg });
 	}
 
 	@Override
@@ -159,7 +159,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void debug(Marker marker, String format, Object arg) {
-		debug(marker, format, (Object[]) arg);
+		debug(marker, format, new Object[] { arg });
 	}
 
 	@Override
@@ -197,7 +197,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void info(String format, Object arg) {
-		info(format, (Object[]) arg);
+		info(format, new Object[] { arg });
 	}
 
 	@Override
@@ -225,7 +225,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void info(Marker marker, String format, Object arg) {
-		info(marker, format, (Object[]) arg);
+		info(marker, format, new Object[] { arg });
 	}
 
 	@Override
@@ -263,7 +263,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void warn(String format, Object arg) {
-		warn(format, (Object[]) arg);
+		warn(format, new Object[] { arg });
 	}
 
 	@Override
@@ -291,7 +291,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void warn(Marker marker, String format, Object arg) {
-		warn(marker, format, (Object[]) arg);
+		warn(marker, format, new Object[] { arg });
 	}
 
 	@Override
@@ -329,7 +329,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void error(String format, Object arg) {
-		error(format, (Object[]) arg);
+		error(format, new Object[] { arg });
 	}
 
 	@Override
@@ -357,7 +357,7 @@ public abstract class InterceptingLogger implements Logger {
 
 	@Override
 	public void error(Marker marker, String format, Object arg) {
-		error(marker, format, (Object[]) arg);
+		error(marker, format, new Object[] { arg });
 	}
 
 	@Override

--- a/recaf-core/src/main/java/me/coley/recaf/util/logging/Logging.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/logging/Logging.java
@@ -22,19 +22,17 @@ public class Logging {
 	 * @return Logger associated with name.
 	 */
 	public static Logger get(String name) {
-		return loggers.computeIfAbsent(name,
-				k -> intercept(name, LoggerFactory.getLogger(name)));
+		return loggers.computeIfAbsent(name, k -> intercept(name, LoggerFactory.getLogger(name)));
 	}
 
 	/**
-	 * @param clazz
+	 * @param cls
 	 * 		Logger class key.
 	 *
 	 * @return Logger associated with class.
 	 */
-	public static Logger get(Class<?> clazz) {
-		return loggers.computeIfAbsent(clazz.getName(),
-				k -> intercept(clazz.getName(), LoggerFactory.getLogger(clazz)));
+	public static Logger get(Class<?> cls) {
+		return loggers.computeIfAbsent(cls.getName(), k -> intercept(cls.getName(), LoggerFactory.getLogger(cls)));
 	}
 
 	private static Logger intercept(String name, Logger logger) {

--- a/recaf-core/src/main/java/me/coley/recaf/util/logging/Logging.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/logging/Logging.java
@@ -1,0 +1,57 @@
+package me.coley.recaf.util.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link LoggerFactory} wrapper that lets us intercept all logged messages.
+ *
+ * @author Matt Coley
+ */
+public class Logging {
+	private static final Map<String, Logger> loggers = new HashMap<>();
+
+	/**
+	 * @param name
+	 * 		Logger name.
+	 *
+	 * @return Logger associated with name.
+	 */
+	public static Logger get(String name) {
+		return loggers.computeIfAbsent(name,
+				k -> intercept(name, LoggerFactory.getLogger(name)));
+	}
+
+	/**
+	 * @param clazz
+	 * 		Logger class key.
+	 *
+	 * @return Logger associated with class.
+	 */
+	public static Logger get(Class<?> clazz) {
+		return loggers.computeIfAbsent(clazz.getName(),
+				k -> intercept(clazz.getName(), LoggerFactory.getLogger(clazz)));
+	}
+
+	private static Logger intercept(String name, Logger logger) {
+		// TODO: Log to file
+		// TODO: Allow foreign classes to access logging in some way, probably like this:
+		//  - List of BiConsumer<Level, String>
+		//  - List of BiConsumer<Level, Throwable>
+		return new InterceptingLogger(logger) {
+			@Override
+			public void log(Level level, String message) {
+
+			}
+
+			@Override
+			public void log(Level level, Throwable t) {
+
+			}
+		};
+	}
+}

--- a/recaf-core/src/test/java/me/coley/recaf/compile/JavacTests.java
+++ b/recaf-core/src/test/java/me/coley/recaf/compile/JavacTests.java
@@ -1,0 +1,35 @@
+package me.coley.recaf.compile;
+
+import me.coley.recaf.TestUtils;
+import me.coley.recaf.compile.javac.JavacCompiler;
+import me.coley.recaf.workspace.resource.ClassInfo;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JavacTests extends TestUtils implements Opcodes {
+	@Test
+	void compileSampleDefaults() throws IOException {
+		// input
+		Path source = sourcesDir.resolve("Sample.java");
+		String name = "Sample";
+		String code = new String(Files.readAllBytes(source));
+		// compile
+		JavacCompiler compiler = new JavacCompiler();
+		CompilerResult result = compiler.compile(name, code);
+		// validate
+		assertTrue(result.wasSuccess());
+		assertEquals(1, result.getValue().size());
+		byte[] compiled = result.getValue().get(name);
+		assertNotNull(compiled);
+		ClassInfo info = ClassInfo.read(compiled);
+		assertEquals(name, info.getName());
+		assertEquals(0, info.getFields().size());
+		assertEquals(2, info.getMethods().size()); // main + ctor
+	}
+}

--- a/recaf-core/src/test/java/me/coley/recaf/compile/JavacTests.java
+++ b/recaf-core/src/test/java/me/coley/recaf/compile/JavacTests.java
@@ -32,4 +32,18 @@ public class JavacTests extends TestUtils implements Opcodes {
 		assertEquals(0, info.getFields().size());
 		assertEquals(2, info.getMethods().size()); // main + ctor
 	}
+
+	@Test
+	void compileSampleFailing() throws IOException {
+		// input
+		Path source = sourcesDir.resolve("SampleFailing.java");
+		String name = "Sample";
+		String code = new String(Files.readAllBytes(source));
+		// compile
+		JavacCompiler compiler = new JavacCompiler();
+		CompilerResult result = compiler.compile(name, code);
+		// validate
+		assertFalse(result.wasSuccess());
+		assertEquals(2, result.getErrors().size());
+	}
 }

--- a/recaf-core/src/test/resources/content-sources/SampleFailing.java
+++ b/recaf-core/src/test/resources/content-sources/SampleFailing.java
@@ -1,0 +1,16 @@
+public class Sample {
+	public static void main(String[] args) // Missing {
+		System.out.println("Sample");
+	}
+}
+/*
+javac SampleFailing.java
+
+SampleFailing.java:2: error: ';' expected
+        public static void main(String[] args)
+                                              ^
+SampleFailing.java:5: error: class, interface, or enum expected
+}
+^
+2 errors
+*/


### PR DESCRIPTION
Implements the Compiler abstract class with `javac` integration.

This requires some creation of a few utilities:

- Common Recaf directories
    - Knowing the current OS for specific cases
- Getting the current Java version
- Logging