### PR TITLE
Escape abritrary strings in assembler instructions

### DIFF
--- a/src/main/java/me/coley/recaf/parse/bytecode/Disassembler.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/Disassembler.java
@@ -279,15 +279,22 @@ public class Disassembler {
 		// Sometimes its not though.
 		Type type = insn.desc.contains(";") ?
 				Type.getType(insn.desc) : Type.getObjectType(insn.desc);
-		line.append(' ').append(type.getInternalName());
+		String name = EscapeUtil.escape(type.getInternalName());
+		line.append(' ').append(name);
 	}
 
 	private void visitFieldInsn(StringBuilder line, FieldInsnNode insn) {
-		line.append(' ').append(insn.owner).append('.').append(insn.name).append(' ').append(insn.desc);
+		String owner = EscapeUtil.escape(insn.owner);
+		String name = EscapeUtil.escape(insn.name);
+		String desc = EscapeUtil.escape(insn.desc);
+		line.append(' ').append(owner).append('.').append(name).append(' ').append(desc);
 	}
 
 	private void visitMethodInsn(StringBuilder line, MethodInsnNode insn) {
-		line.append(' ').append(insn.owner).append('.').append(insn.name).append(insn.desc);
+		String owner = EscapeUtil.escapeCommon(insn.owner);
+		String name = EscapeUtil.escapeCommon(insn.name);
+		String desc = EscapeUtil.escapeCommon(insn.desc);
+		line.append(' ').append(owner).append('.').append(name).append(desc);
 	}
 
 	private void visitJumpInsn(StringBuilder line, JumpInsnNode insn) {
@@ -307,7 +314,8 @@ public class Disassembler {
 		line.append(' ');
 		if(insn.cst instanceof String) {
 			String str = insn.cst.toString();
-			str = EscapeUtil.escapeCommon(str);
+			// TODO: support for escaping "
+			str = EscapeUtil.escape(str);
 			line.append('"').append(str).append('"');
 		} else if (insn.cst instanceof Long)
 			line.append(insn.cst).append('L');
@@ -370,7 +378,9 @@ public class Disassembler {
 
 	private void visitIndyInsn(StringBuilder line, InvokeDynamicInsnNode insn) {
 		// append nsmr & desc
-		line.append(' ').append(insn.name).append(' ').append(insn.desc).append(' ');
+		String name = EscapeUtil.escape(insn.name);
+		String desc = EscapeUtil.escape(insn.desc);
+		line.append(' ').append(name).append(' ').append(desc).append(' ');
 		// append handle
 		visitHandle(line, insn.bsm, false);
 		// append args
@@ -402,13 +412,16 @@ public class Disassembler {
 			line.append("${" + HandleParser.DEFAULT_HANDLE_ALIAS + "}");
 			return;
 		}
+		String owner = EscapeUtil.escape(handle.getOwner());
+		String name = EscapeUtil.escape(handle.getName());
+		String desc = EscapeUtil.escape(handle.getDesc());
 		line.append("handle[");
 		line.append(OpcodeUtil.tagToName(handle.getTag()));
-		line.append(' ').append(handle.getOwner());
-		line.append('.').append(handle.getName());
+		line.append(' ').append(owner);
+		line.append('.').append(name);
 		if (handle.getTag() >= Opcodes.H_GETFIELD && handle.getTag() <= Opcodes.H_PUTSTATIC)
 			line.append(' ');
-		line.append(handle.getDesc());
+		line.append(desc);
 		line.append(']');
 	}
 

--- a/src/main/java/me/coley/recaf/parse/bytecode/Disassembler.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/Disassembler.java
@@ -314,7 +314,6 @@ public class Disassembler {
 		line.append(' ');
 		if(insn.cst instanceof String) {
 			String str = insn.cst.toString();
-			// TODO: support for escaping "
 			str = EscapeUtil.escape(str);
 			line.append('"').append(str).append('"');
 		} else if (insn.cst instanceof Long)

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/DescAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/DescAST.java
@@ -1,4 +1,6 @@
 package me.coley.recaf.parse.bytecode.ast;
+	
+import me.coley.recaf.util.EscapeUtil;
 
 /**
  * Member descriptor AST.
@@ -26,6 +28,13 @@ public class DescAST extends AST {
 	 */
 	public String getDesc() {
 		return desc;
+	}
+	
+	/**
+	 * @return Desc without escapes.
+	 */
+	public String getUnescapedDesc() {
+		return EscapeUtil.unescape(desc);
 	}
 
 	@Override

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/HandleAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/HandleAST.java
@@ -79,7 +79,7 @@ public class HandleAST extends AST {
 	 * @return ASM handle from AST data.
 	 */
 	public Handle compile() {
-		return new Handle(getTag().getTag(), getOwner().getType(), getName().getName(),
-				getDesc().getDesc(), getTag().getTag() == Opcodes.H_INVOKEINTERFACE);
+		return new Handle(getTag().getTag(), getOwner().getUnescapedType(), getName().getUnescapedName(),
+				getDesc().getUnescapedDesc(), getTag().getTag() == Opcodes.H_INVOKEINTERFACE);
 	}
 }

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/InvokeDynamicAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/InvokeDynamicAST.java
@@ -93,7 +93,7 @@ public class InvokeDynamicAST extends InsnAST {
 			if(arg instanceof NumberAST) {
 				convertedArgs[i] = ((NumberAST) arg).getValue();
 			} else if(arg instanceof StringAST) {
-				convertedArgs[i] = ((StringAST) arg).getValue();
+				convertedArgs[i] = ((StringAST) arg).getUnescapedValue();
 			} else if(arg instanceof HandleAST) {
 				convertedArgs[i] = ((HandleAST) arg).compile();
 			} else if(arg instanceof TypeAST) {
@@ -102,7 +102,7 @@ public class InvokeDynamicAST extends InsnAST {
 				convertedArgs[i] = Type.getType(((DescAST) arg).getDesc());
 			}
 		}
-		compilation.addInstruction(new InvokeDynamicInsnNode(getName().getName(), getDesc().getDesc(),
+		compilation.addInstruction(new InvokeDynamicInsnNode(getName().getUnescapedName(), getDesc().getUnescapedDesc(),
 				getHandle().compile(), convertedArgs), this);
 	}
 }

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/NameAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/NameAST.java
@@ -1,5 +1,7 @@
 package me.coley.recaf.parse.bytecode.ast;
 
+import me.coley.recaf.util.EscapeUtil;
+
 /**
  * Generic name AST.
  *
@@ -26,6 +28,13 @@ public class NameAST extends AST {
 	 */
 	public String getName() {
 		return name;
+	}
+	
+	/**
+	 * @return Name without escapes.
+	 */
+	public String getUnescapedName() {
+		return EscapeUtil.unescape(name);
 	}
 
 

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/TypeAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/TypeAST.java
@@ -1,5 +1,7 @@
 package me.coley.recaf.parse.bytecode.ast;
 
+import me.coley.recaf.util.EscapeUtil;
+
 /**
  * Internal name AST.
  *
@@ -26,6 +28,13 @@ public class TypeAST extends AST {
 	 */
 	public String getType() {
 		return type;
+	}
+
+	/**
+	 * @return Internal type without escapes.
+	 */
+	public String getUnescapedType() {
+		return EscapeUtil.unescape(type);
 	}
 
 	@Override

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/DescParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/DescParser.java
@@ -5,6 +5,7 @@ import me.coley.recaf.parse.bytecode.ast.*;
 import me.coley.recaf.parse.bytecode.exception.ASTParseException;
 import me.coley.recaf.util.AutoCompleteUtil;
 import org.objectweb.asm.Type;
+import me.coley.recaf.util.EscapeUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,7 @@ public class DescParser extends AbstractParser<DescAST> {
 	public DescAST visit(int lineNo, String line) throws ASTParseException {
 		try {
 			String trim = line.trim();
+			trim = EscapeUtil.unescape(trim);
 			// Verify
 			if(trim.contains("(")) {
 				Type type = Type.getMethodType(trim);

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/NameParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/NameParser.java
@@ -3,6 +3,7 @@ package me.coley.recaf.parse.bytecode.parser;
 import me.coley.recaf.parse.bytecode.*;
 import me.coley.recaf.parse.bytecode.ast.*;
 import me.coley.recaf.parse.bytecode.exception.ASTParseException;
+import me.coley.recaf.util.EscapeUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -30,8 +31,7 @@ public class NameParser extends AbstractParser<NameAST> {
 			String trim = line.trim();
 			if (trim.isEmpty())
 				throw new ASTParseException(lineNo, "Name cannot be empty!");
-			if (!trim.matches("\\S+"))
-				throw new ASTParseException(lineNo, "Name cannot contain whitespace characters");
+			trim = EscapeUtil.unescape(trim);
 			int start = line.indexOf(trim);
 			return new NameAST(lineNo, getOffset() + start, trim);
 		} catch (Exception ex) {

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/TypeParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/TypeParser.java
@@ -5,6 +5,7 @@ import me.coley.recaf.parse.bytecode.ast.RootAST;
 import me.coley.recaf.parse.bytecode.ast.TypeAST;
 import me.coley.recaf.parse.bytecode.exception.ASTParseException;
 import me.coley.recaf.util.AutoCompleteUtil;
+import me.coley.recaf.util.EscapeUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +20,7 @@ public class TypeParser extends AbstractParser<TypeAST> {
 	public TypeAST visit(int lineNo, String line) throws ASTParseException {
 		try {
 			String trim = line.trim();
+			trim = EscapeUtil.unescape(trim);
 			if (trim.charAt(0) == '[') {
 				// Handle array types
 				if (!trim.matches("\\S+"))


### PR DESCRIPTION
## What's new

Some instructions that have the ability to print arbitrary strings will have the printed contents escaped, so some non alphanumeric characters will be replaced with escape sequences.
These escape sequences will be decoded upon compilation.

## What's fixed

Previously some class names, especially those with unicode characters and new line characters, would be printed by the disassembler output, resulting in an invalid input for the assembler.

[example.zip](https://github.com/Col-E/Recaf/files/6058472/example.zip)


There are still many places that I can see where the assembler can be exploited, however this should fix one common place.
This was especially noticeable in field instructions accessing fields in classes with obfuscated names.

I have run some of my own tests as well as the official tests and see no errors, so it should be fine.