### PR TITLE
3X: Config system

### DIFF
--- a/recaf-ui/src/main/java/me/coley/recaf/config/ConfigContainer.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/config/ConfigContainer.java
@@ -1,0 +1,18 @@
+package me.coley.recaf.config;
+
+/**
+ * Container of config values, marked with {@link ConfigID}.
+ *
+ * @author Matt Coley
+ */
+public interface ConfigContainer {
+	/**
+	 * @return Display name for the {@link #internalName() internal name} to show in UI's.
+	 */
+	String displayName();
+
+	/**
+	 * @return Internal name of contained config items. Used as a prefix for items marked with {@link ConfigID}.
+	 */
+	String internalName();
+}

--- a/recaf-ui/src/main/java/me/coley/recaf/config/ConfigID.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/config/ConfigID.java
@@ -1,0 +1,38 @@
+package me.coley.recaf.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation applied to a field to indicate it should be serialized/deserialized and shown in the config UI.
+ * Supplies UI text for the field via the translation key given in {@link #value()}.
+ *
+ * @author Matt Coley
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ConfigID {
+	/**
+	 * @return Translation key for fetching name and descriptions of the config value.
+	 */
+	String value();
+
+	/**
+	 * Hidden values can be used for more backend/testing settings.
+	 *
+	 * @return {@code true} to hide from UI.
+	 */
+	boolean hidden() default false;
+
+	/**
+	 * Allow the {@link #value()} to be marked as translatable.
+	 * Normally all items should be, but in some cases <i>(plugins)</i> it may not be
+	 * immediately available as an option.
+	 *
+	 * @return {@code true} when the {@link #value()} indicates a translation key.
+	 * {@code false} when it is literal text.
+	 */
+	boolean translatable() default true;
+}

--- a/recaf-ui/src/main/java/me/coley/recaf/config/ConfigRegistry.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/config/ConfigRegistry.java
@@ -1,0 +1,162 @@
+package me.coley.recaf.config;
+
+import me.coley.recaf.ui.util.Lang;
+import me.coley.recaf.util.ReflectionUtil;
+import me.coley.recaf.util.logging.Logging;
+import org.slf4j.Logger;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Config value persistence and general management.
+ *
+ * @author Matt Coley
+ */
+public class ConfigRegistry {
+	private static final Logger logger = Logging.get(ConfigRegistry.class);
+	private static final Map<String, String> idToDisplay = new TreeMap<>();
+	private static final Map<String, Supplier<?>> idToGetter = new TreeMap<>();
+	private static final Map<String, Consumer<?>> idToSetter = new TreeMap<>();
+	private static final List<ConfigContainer> containers = new ArrayList<>();
+
+	/**
+	 * @param container
+	 * 		Field container instance.
+	 */
+	public static void register(ConfigContainer container) {
+		logger.debug("Register config container: " + container.displayName());
+		// Cache fields
+		for (Field field : container.getClass().getDeclaredFields()) {
+			field.setAccessible(true);
+			String id = getFieldID(container, field);
+			if (id == null)
+				continue;
+			idToDisplay.put(id, getFieldDisplay(field, id));
+			idToGetter.put(id, createGetter(container, field));
+			idToSetter.put(id, createSetter(container, field));
+		}
+		// Store ref to container
+		containers.add(container);
+	}
+
+	/**
+	 * Save registered {@link ConfigContainer} values.
+	 */
+	public static void load() {
+		for (ConfigContainer container : containers) {
+			// TODO: JSON persistence
+		}
+	}
+
+	/**
+	 * Save registered {@link ConfigContainer} values.
+	 */
+	public static void save() {
+		for (ConfigContainer container : containers) {
+			// TODO: JSON persistence
+		}
+	}
+
+	/**
+	 * @param id
+	 * 		Config field id, see {@link #getFieldID(ConfigContainer, Field)}
+	 * @param <T>
+	 * 		Field type.
+	 *
+	 * @return Getter for the field.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> Supplier<T> getter(String id) {
+		return (Supplier<T>) idToGetter.get(id);
+	}
+
+	/**
+	 * @param id
+	 * 		Config field id, see {@link #getFieldID(ConfigContainer, Field)}
+	 * @param <T>
+	 * 		Field type.
+	 *
+	 * @return Setter for the field.
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> Consumer<T> setter(String id) {
+		return (Consumer<T>) idToSetter.get(id);
+	}
+
+
+	/**
+	 * @param container
+	 * 		Field container instance.
+	 * @param field
+	 * 		Field instance.
+	 *
+	 * @return Getter for field value.
+	 */
+	private static Supplier<?> createGetter(ConfigContainer container, Field field) {
+		return () -> ReflectionUtil.quietGet(container, field);
+	}
+
+	/**
+	 * @param container
+	 * 		Field container instance.
+	 * @param field
+	 * 		Field instance.
+	 *
+	 * @return Setter for field value.
+	 */
+	private static Consumer<?> createSetter(ConfigContainer container, Field field) {
+		return value -> ReflectionUtil.quietSet(container, field, value);
+	}
+
+	/**
+	 * @param field
+	 * 		Field instance.
+	 * @param key
+	 * 		Translation key lookup.
+	 *
+	 * @return Display text for the configurable field.
+	 */
+	public static String getFieldDisplay(Field field, String key) {
+		// Check cached values
+		if (idToDisplay.containsKey(key))
+			return idToDisplay.get(key);
+		// Get display
+		ConfigID id = field.getAnnotation(ConfigID.class);
+		if (id == null)
+			return null;
+		// Get translatable text, if possible. Otherwise use the value as-is.
+		if (id.translatable())
+			return Lang.get(key);
+		else
+			return id.value();
+	}
+
+	/**
+	 * @param container
+	 * 		Field container instance.
+	 * @param field
+	 * 		Field instance.
+	 *
+	 * @return Internal identifier string, or {@code null} if the field is not marked with {@link ConfigID}.
+	 */
+	public static String getFieldID(ConfigContainer container, Field field) {
+		// Get config field identity
+		ConfigID id = field.getAnnotation(ConfigID.class);
+		if (id == null)
+			return null;
+		String key = id.value();
+		// Add sub-group
+		Group group = field.getAnnotation(Group.class);
+		if (group != null)
+			key = group.value() + "." + key;
+		// Add main group
+		key = container.internalName() + "." + key;
+		return key;
+	}
+}

--- a/recaf-ui/src/main/java/me/coley/recaf/config/Configs.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/config/Configs.java
@@ -1,0 +1,29 @@
+package me.coley.recaf.config;
+
+import me.coley.recaf.config.container.DisplayConfig;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Instance manager of {@link ConfigContainer} instances.
+ *
+ * @author Matt Coley
+ */
+public class Configs {
+	private static final DisplayConfig display = new DisplayConfig();
+
+	/**
+	 * @return Collection of all config container instances.
+	 */
+	public static Collection<ConfigContainer> containers() {
+		return Arrays.asList(display());
+	}
+
+	/**
+	 * @return Display config instance.
+	 */
+	public static DisplayConfig display() {
+		return display;
+	}
+}

--- a/recaf-ui/src/main/java/me/coley/recaf/config/Group.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/config/Group.java
@@ -1,0 +1,33 @@
+package me.coley.recaf.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation applied to a field to create groups inside of config classes.
+ * For example, in the UI config class there could be groupings for:
+ * <ul>
+ *     <li>Tree display options</li>
+ *     <li>Code display options</li>
+ *     <li>Theme/style options</li>
+ *     <li>etc</li>
+ * </ul>
+ *
+ * @author Matt Coley
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Group {
+	/**
+	 * A group is applied to some fields of a class containing {@link ConfigID} marked fields.
+	 * The class container will have the major category grouping, and this will supply optional sub-groups
+	 * for some fields.
+	 * <br>
+	 * This can allow similar item groups under the major category to be grouped together.
+	 *
+	 * @return Translation key suffix for the category, creating an effective sub-group.
+	 */
+	String value();
+}

--- a/recaf-ui/src/main/java/me/coley/recaf/config/container/DisplayConfig.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/config/container/DisplayConfig.java
@@ -1,0 +1,30 @@
+package me.coley.recaf.config.container;
+
+import me.coley.recaf.config.ConfigContainer;
+import me.coley.recaf.config.ConfigID;
+import me.coley.recaf.config.Group;
+import me.coley.recaf.ui.util.Lang;
+
+/**
+ * Config container for display values.
+ *
+ * @author Matt Coley
+ */
+public class DisplayConfig implements ConfigContainer {
+	/**
+	 * Maximum depth of a directory structure to display before it gets truncated.
+	 */
+	@Group("tree")
+	@ConfigID("maxtreedirectorydepth")
+	public int maxTreeDirectoryDepth = 35;
+
+	@Override
+	public String displayName() {
+		return Lang.get(internalName());
+	}
+
+	@Override
+	public String internalName() {
+		return "conf.display";
+	}
+}

--- a/recaf-ui/src/main/java/me/coley/recaf/presentation/GuiPresentation.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/presentation/GuiPresentation.java
@@ -3,9 +3,11 @@ package me.coley.recaf.presentation;
 import me.coley.recaf.Controller;
 import me.coley.recaf.RecafConstants;
 import me.coley.recaf.RecafUI;
+import me.coley.recaf.config.ConfigRegistry;
+import me.coley.recaf.config.Configs;
 import me.coley.recaf.ui.util.JFXUtils;
 import me.coley.recaf.ui.util.Lang;
-import me.coley.recaf.util.JFXInjection;
+import me.coley.recaf.ui.util.JFXInjection;
 import me.coley.recaf.util.LoggerConsumerImpl;
 import me.coley.recaf.util.Threads;
 import me.coley.recaf.util.logging.Logging;
@@ -28,8 +30,11 @@ public class GuiPresentation implements Presentation {
 		// Setup JavaFX
 		JFXInjection.ensureJavafxSupport();
 		JFXUtils.initializePlatform();
-		// Open translations
+		// Load translations
 		Lang.load();
+		// Setup config
+		Configs.containers().forEach(ConfigRegistry::register);
+		ConfigRegistry.load();
 		// Open UI
 		JFXUtils.runSafe(() -> {
 			try {

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/tree/item/ResourceItem.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/tree/item/ResourceItem.java
@@ -1,6 +1,7 @@
 package me.coley.recaf.ui.control.tree.item;
 
 import me.coley.recaf.RecafUI;
+import me.coley.recaf.config.Configs;
 import me.coley.recaf.workspace.resource.Resource;
 
 import java.util.*;
@@ -91,6 +92,15 @@ public class ResourceItem extends BaseTreeItem {
 						 Function<String, BaseTreeItem> leafFunction,
 						 Function<String, BaseTreeItem> branchFunction) {
 		List<String> parts = new ArrayList<>(Arrays.asList(name.split("/")));
+		// Prune tree directory middle section if it is obnoxiously long
+		int maxDepth = Configs.display().maxTreeDirectoryDepth;
+		if (maxDepth > 0 && parts.size() > maxDepth) {
+			while (parts.size() > maxDepth) {
+				parts.remove(maxDepth - 1);
+			}
+			parts.add(maxDepth - 1, "...");
+		}
+		// Build directory structure
 		while(!parts.isEmpty()) {
 			String part = parts.remove(0);
 			boolean isLeaf = parts.isEmpty();

--- a/recaf-ui/src/main/java/me/coley/recaf/util/ReflectionUtil.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/util/ReflectionUtil.java
@@ -1,0 +1,98 @@
+package me.coley.recaf.util;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Reflection utility for field get/set operations.
+ *
+ * @author Matt Coley
+ */
+public class ReflectionUtil {
+	private static final Map<Class<?>, ThrowableGetter<?>> GETTERS = new HashMap<>();
+	private static final Map<Class<?>, ThrowableSetter<?>> SETTERS = new HashMap<>();
+	private static final ThrowableGetter<?> DEFAULT_GETTER = Field::get;
+	private static final ThrowableSetter<?> DEFAULT_SETTER = Field::set;
+
+	static {
+		// Getters
+		GETTERS.put(boolean.class, (ThrowableGetter<Boolean>) Field::getBoolean);
+		GETTERS.put(byte.class, (ThrowableGetter<Byte>) Field::getByte);
+		GETTERS.put(char.class, (ThrowableGetter<Character>) Field::getChar);
+		GETTERS.put(short.class, (ThrowableGetter<Short>) Field::getShort);
+		GETTERS.put(int.class, (ThrowableGetter<Integer>) Field::getInt);
+		GETTERS.put(long.class, (ThrowableGetter<Long>) Field::getLong);
+		GETTERS.put(float.class, (ThrowableGetter<Float>) Field::getFloat);
+		GETTERS.put(double.class, (ThrowableGetter<Double>) Field::getDouble);
+		// Setters
+		SETTERS.put(boolean.class, (ThrowableSetter<Boolean>) Field::setBoolean);
+		SETTERS.put(byte.class, (ThrowableSetter<Byte>) Field::setByte);
+		SETTERS.put(char.class, (ThrowableSetter<Character>) Field::setChar);
+		SETTERS.put(short.class, (ThrowableSetter<Short>) Field::setShort);
+		SETTERS.put(int.class, (ThrowableSetter<Integer>) Field::setInt);
+		SETTERS.put(long.class, (ThrowableSetter<Long>) Field::setLong);
+		SETTERS.put(float.class, (ThrowableSetter<Float>) Field::setFloat);
+		SETTERS.put(double.class, (ThrowableSetter<Double>) Field::setDouble);
+	}
+
+	/**
+	 * @param instance
+	 * 		Field owner instance.
+	 * @param field
+	 * 		Field to set value of.
+	 * @param value
+	 * 		Value to set.
+	 * @param <T>
+	 * 		Assumed field type.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> void quietSet(Object instance, Field field, T value) {
+		try {
+			ThrowableSetter<T> setter = (ThrowableSetter<T>) SETTERS.getOrDefault(field.getType(), DEFAULT_SETTER);
+			setter.set(field, instance, value);
+		} catch (IllegalAccessException ex) {
+			throw new IllegalStateException("Setter failure: " + instance.getClass() + "." + field.getName(), ex);
+		}
+	}
+
+	/**
+	 * @param instance
+	 * 		Field owner instance.
+	 * @param field
+	 * 		Field to get value from.
+	 * @param <T>
+	 * 		Assumed field type.
+	 *
+	 * @return Value.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T quietGet(Object instance, Field field) {
+		try {
+			ThrowableGetter<T> getter = (ThrowableGetter<T>) GETTERS.getOrDefault(field.getType(), DEFAULT_GETTER);
+			return getter.get(field, instance);
+		} catch (IllegalAccessException ex) {
+			throw new IllegalStateException("Getter failure: " + instance.getClass() + "." + field.getName(), ex);
+		}
+	}
+
+	/**
+	 * Functional interface for field set operations.
+	 *
+	 * @param <T>
+	 * 		Return type.
+	 */
+	private interface ThrowableSetter<T> {
+		void set(Field field, Object instance, T value) throws IllegalAccessException;
+	}
+
+	/**
+	 * Functional interface for field get operations.
+	 *
+	 * @param <T>
+	 * 		Parameter type.
+	 */
+	private interface ThrowableGetter<T> {
+		T get(Field field, Object instance) throws IllegalAccessException;
+	}
+}

--- a/recaf-ui/src/main/resources/lang/en.lang
+++ b/recaf-ui/src/main/resources/lang/en.lang
@@ -18,6 +18,7 @@ wizard.chooseaction=Choose an action
 wizard.selectprimary=Select primary resource
 wizard.currentworkspace=Current workspace
 
+
 ##### Panels
 
 ## Welcome
@@ -33,3 +34,8 @@ welcome.github.description=Check out the project page on GitHub: Source code, op
 tree.classes=Classes
 tree.files=Files
 tree.prompt=Drag your files here
+
+
+##### Config
+conf.display=Display
+conf.display.tree.maxtreedirectorydepth=Max tree directory depth


### PR DESCRIPTION
This is the setup for the config system in Recaf 3X.

Major differences:
 - Not bound to controller for easy access from anywhere
 - Easily extensible by registering new config containers

The config is no longer bound to the controller because the controller logic is for the most part, only what is defined in the `core` module. The `core` functionality will be handled as a library and config items will be passed to it over method parameters. This fixes a long standing issue of config and controller access being intertwined with core logic.

As for extensibility, the way the system works in 2X makes it a bit wonky for adding custom additions. This should make it very easy to create plugins with multiple configurable values.