### PR TITLE
Allow zip files to be opened as jar files

### DIFF
--- a/src/main/java/me/coley/recaf/workspace/FileSystemResource.java
+++ b/src/main/java/me/coley/recaf/workspace/FileSystemResource.java
@@ -52,6 +52,7 @@ public abstract class FileSystemResource extends JavaResource {
 			case "class":
 				return new ClassResource(path);
 			case "jar":
+			case "zip":
 				return new JarResource(path);
 			case "war":
 				return new WarResource(path);


### PR DESCRIPTION
### Allows zip files to be opened like jar files
Since I use Recaf to analyze malicious programs, I'd rather store the programs as .zip files so that they don't run when I click them. This PR just adds zip to the file extensions which are allowed to be opened with Recaf.