### PR TITLE
Backport alternative class reading method for invalid class CRCs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>me.coley</groupId>
 	<artifactId>recaf</artifactId>
 	<url>https://github.com/Col-E/Recaf/</url>
-	<version>2.21.8</version>
+	<version>2.21.9</version>
 	<name>Recaf</name>
 	<description>A modern java bytecode editor</description>
 	<!-- Variables -->

--- a/src/main/java/me/coley/recaf/Recaf.java
+++ b/src/main/java/me/coley/recaf/Recaf.java
@@ -31,7 +31,7 @@ import static me.coley.recaf.util.Log.*;
  * @author Matt
  */
 public class Recaf {
-	public static final String VERSION = "2.21.8";
+	public static final String VERSION = "2.21.9";
 	public static final String DOC_URL = "https://col-e.github.io/Recaf-documentation/";
 	public static final int ASM_VERSION = Opcodes.ASM9;
 	private static Controller currentController;

--- a/src/main/java/me/coley/recaf/workspace/JarResource.java
+++ b/src/main/java/me/coley/recaf/workspace/JarResource.java
@@ -6,6 +6,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
@@ -34,20 +35,48 @@ public class JarResource extends ArchiveResource {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		byte[] buffer = new byte[8192];
 		EntryLoader loader = getEntryLoader();
-		ZipInputStream zis = new ZipInputStream(new FileInputStream(getPath().toFile()));
-		ZipEntry entry;
-		while ((entry = zis.getNextEntry()) != null) {
-			// verify entries are classes and valid files
-			// - skip intentional garbage / zip file abnormalities
-			if (shouldSkip(entry.getName()))
-				continue;
-			if (loader.isValidClassEntry(entry)) {
+
+		try {
+			ZipInputStream zis = new ZipInputStream(new FileInputStream(getPath().toFile()));
+			ZipEntry entry;
+
+			while ((entry = zis.getNextEntry()) != null) {
+				// verify entries are classes and valid files
+				// - skip intentional garbage / zip file abnormalities
+				if (shouldSkip(entry.getName()))
+					continue;
+				if (!loader.isValidClassEntry(entry))
+					continue;
+
 				out.reset();
 				byte[] in = IOUtil.toByteArray(zis, out, buffer);
+
 				// There is no possible way a "class" under 30 bytes is valid
 				if (in.length < 30)
 					continue;
+
 				loader.onClass(entry.getName(), in);
+			}
+		} catch (ZipException e) {
+			if (e.getMessage().contains("invalid entry CRC")) {
+				// "ZipFile"/"JarFile" reads the entire ZIP file structure before letting us do any entry parsing.
+				// This may not always be ideal, but this way has one major bonus. It totally ignores CRC validity.
+				// It also ignores a few other zip entry values.
+				// Since somebody can intentionally write bogus data there to crash "ZipInputStream" this way works.
+				ZipFile zf = new ZipFile(getPath().toString());
+				Enumeration<? extends ZipEntry> entries = zf.entries();
+				while (entries.hasMoreElements()) {
+					ZipEntry entry = entries.nextElement();
+
+					if (shouldSkip(entry.getName()))
+						continue;
+					if (!loader.isValidClassEntry(entry))
+						continue;
+
+					InputStream zis = zf.getInputStream(entry);
+					byte[] in = IOUtil.toByteArray(zis);
+					loader.onClass(entry.getName(), in);
+				}
 			}
 		}
 		loader.finishClasses();


### PR DESCRIPTION
## What's new

* Fix https://github.com/Col-E/Recaf/issues/440 / https://github.com/Col-E/Recaf/issues/403
