### PR TITLE
Update jelf to 0.7.0 + small ELF explorer improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ subprojects {
         logback_classic = 'ch.qos.logback:logback-classic:1.2.3'
         pe = 'com.github.cademtz:JavaPeParser:1.0.0'
         javassist = 'org.javassist:javassist:3.28.0-GA'
-        jelf = 'net.fornwall:jelf:0.6.0'
+        jelf = 'net.fornwall:jelf:0.7.0'
         picocli = 'info.picocli:picocli:4.6.1'
         regex = 'net.sourceforge.jregex:jregex:1.2_01'
         richtextfx = 'org.fxmisc.richtext:richtextfx:0.10.6'

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ElfExplorerPane.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ElfExplorerPane.java
@@ -87,17 +87,13 @@ public class ElfExplorerPane extends SplitPane implements FileRepresentation {
 			logger.error("Failed to parse ELF file: {}", e.getMessage());
 		}
 
-		logger.info("PH COUNT {}", elfFile.e_phnum);
 		for (int i = 0; i < elfFile.e_phnum; i++) {
-			logger.info("PH {}, TYPE {}", i, elfFile.getProgramHeader(i).p_type);
 			TreeItem<String> programHeaderItem = new TreeItem<>(String.format("Header %d", i));
 			itemProgramHeaders.getChildren().add(programHeaderItem);
 		}
 
-		logger.info("SH COUNT {}", elfFile.e_shnum);
 		for (int i = 1; i < elfFile.e_shnum; i++) {
 			ElfSectionHeader sectionHeader = elfFile.getSection(i).header;
-			logger.info("SH {}, NAME {}, TYPE {}", i, sectionHeader.getName(), sectionHeader.sh_type);
 			TreeItem<String> sectionHeaderItem = new TreeItem<>(sectionHeader.getName());
 			itemSectionHeaders.getChildren().add(sectionHeaderItem);
 		}

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ElfExplorerPane.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ElfExplorerPane.java
@@ -87,13 +87,17 @@ public class ElfExplorerPane extends SplitPane implements FileRepresentation {
 			logger.error("Failed to parse ELF file: {}", e.getMessage());
 		}
 
-		for (int i = 0; i < elfFile.num_ph; i++) {
+		logger.info("PH COUNT {}", elfFile.e_phnum);
+		for (int i = 0; i < elfFile.e_phnum; i++) {
+			logger.info("PH {}, TYPE {}", i, elfFile.getProgramHeader(i).p_type);
 			TreeItem<String> programHeaderItem = new TreeItem<>(String.format("Header %d", i));
 			itemProgramHeaders.getChildren().add(programHeaderItem);
 		}
 
-		for (int i = 1; i < elfFile.num_sh; i++) {
+		logger.info("SH COUNT {}", elfFile.e_shnum);
+		for (int i = 1; i < elfFile.e_shnum; i++) {
 			ElfSectionHeader sectionHeader = elfFile.getSection(i).header;
+			logger.info("SH {}, NAME {}, TYPE {}", i, sectionHeader.getName(), sectionHeader.sh_type);
 			TreeItem<String> sectionHeaderItem = new TreeItem<>(sectionHeader.getName());
 			itemSectionHeaders.getChildren().add(sectionHeaderItem);
 		}
@@ -169,7 +173,8 @@ public class ElfExplorerPane extends SplitPane implements FileRepresentation {
 				ElfSegment programHeader = elfFile.getProgramHeader(programHeaderIndex);
 				programHeaderDisplayMode.apply(programHeader, primaryTableView);
 			} else if (sectionHeaderIndex != -1) {
-				ElfSectionHeader sectionHeader = elfFile.getSection(sectionHeaderIndex).header;
+				// Section header indexes start at 1, so we need to add one or else we'll be off by one.
+				ElfSectionHeader sectionHeader = elfFile.getSection(sectionHeaderIndex + 1).header;
 				sectionHeaderDisplayMode.apply(sectionHeader, primaryTableView);
 			} else {
 				primaryTableView.getColumns().clear();

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ElfHeaderDisplayMode.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ElfHeaderDisplayMode.java
@@ -121,24 +121,24 @@ public class ElfHeaderDisplayMode implements TableDisplayMode<ElfFile> {
 	@Override
 	public void apply(ElfFile elf, SizedDataTypeTable table) {
 		table.addDword("ei_mag", 0x464c457f, "Magic number");
-		table.addByte("ei_class", elf.objectSize, elf.objectSize == 1 ? "32 bit binary" : "64 bit binary");
-		table.addByte("ei_data", elf.encoding, elf.encoding == 1 ? "Little endian" : "Big endian");
-		table.addByte("ei_version", elf.elfVersion, elf.elfVersion == 1 ? "Original version of ELF" : "Unknown");
-		table.addByte("ei_osabi", elf.abi, ABI_MAP.getOrDefault((int) elf.abi, "Unknown"));
-		table.addByte("es_abiversion", elf.abiVersion, "ABI version");
+		table.addByte("ei_class", elf.ei_class, elf.ei_class == 1 ? "32 bit binary" : "64 bit binary");
+		table.addByte("ei_data", elf.ei_data, elf.ei_data == 1 ? "Little endian" : "Big endian");
+		table.addByte("ei_version", elf.ei_version, elf.ei_version == 1 ? "Original version of ELF" : "Unknown");
+		table.addByte("ei_osabi", elf.ei_osabi, ABI_MAP.getOrDefault((int) elf.ei_osabi, "Unknown"));
+		table.addByte("es_abiversion", elf.es_abiversion, "ABI version");
 		table.addByte("ei_pad", "00, 00, 00, 00, 00, 00, 00", "Padding (7)");
 		table.addWord("e_type", elf.e_type, OFT_MAP.getOrDefault((int) elf.e_type, "Unknown"));
-		table.addWord("e_machine", elf.arch, ISA_MAP.getOrDefault((int) elf.arch, "Unknown"));
-		table.addDword("e_version", elf.version, elf.version == 1 ? "Original version of ELF" : "Unknown");
-		table.addAddress("e_entry", elf.entry_point, "Address of entry point", elf);
-		table.addAddress("e_phoff", elf.ph_offset, "Start of program header", elf);
-		table.addAddress("e_shoff", elf.sh_offset, "Start of section header", elf);
-		table.addDword("e_flags", elf.flags, "Flags");
-		table.addWord("e_ehsize", elf.eh_size, "Elf header size");
-		table.addWord("e_phentsize", elf.ph_entry_size, "Size of program header entry");
-		table.addWord("e_phnum", elf.num_ph, "Number of program header entries");
-		table.addWord("e_shentsize", elf.sh_entry_size, "Size of section header entry");
-		table.addWord("e_shnum", elf.num_sh, "Number of section header entries");
-		//table.addWord("e_shstrndx", elf.sh_string_ndx, ); figure out if I want a jelf fork just to get access to this field
+		table.addWord("e_machine", elf.e_machine, ISA_MAP.getOrDefault((int) elf.e_machine, "Unknown"));
+		table.addDword("e_version", elf.e_version, elf.e_version == 1 ? "Original version of ELF" : "Unknown");
+		table.addAddress("e_entry", elf.e_entry, "Address of entry point", elf);
+		table.addAddress("e_phoff", elf.e_phoff, "Start of program header", elf);
+		table.addAddress("e_shoff", elf.e_shoff, "Start of section header", elf);
+		table.addDword("e_flags", elf.e_flags, "Flags");
+		table.addWord("e_ehsize", elf.e_ehsize, "Elf header size");
+		table.addWord("e_phentsize", elf.e_phentsize, "Size of program header entry");
+		table.addWord("e_phnum", elf.e_phnum, "Number of program header entries");
+		table.addWord("e_shentsize", elf.e_shentsize, "Size of section header entry");
+		table.addWord("e_shnum", elf.e_shnum, "Number of section header entries");
+		table.addWord("e_shstrndx", elf.e_shstrndx, "Index of section name string table");
 	}
 }

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ProgramHeaderDisplayMode.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ProgramHeaderDisplayMode.java
@@ -36,14 +36,14 @@ public class ProgramHeaderDisplayMode implements ElfTableDisplayMode<ElfSegment>
 
 	@Override
 	public void apply(ElfSegment programHeader, SizedDataTypeTable table) {
-		table.addDword("p_type", programHeader.type, ST_MAP.getOrDefault(programHeader.type, "Unknown"));
-		table.addDword("p_flags", programHeader.flags, "Flags");
-		table.addAddress("p_offset", programHeader.offset, "Offset of segment", elf);
-		table.addAddress("p_vaddr", programHeader.virtual_address, "Virtual address of segment", elf);
-		table.addAddress("p_paddr", programHeader.physical_address, "Physical address of segment", elf);
-		table.addAddress("p_filesz", programHeader.file_size, "Physical size of segment", elf);
-		table.addAddress("p_memsz", programHeader.mem_size, "Virtual size of segment", elf);
-		table.addAddress("p_align", programHeader.alignment, programHeader.alignment <= 1 ? "No alignment" : "Has alignment", elf);
+		table.addDword("p_type", programHeader.p_type, ST_MAP.getOrDefault(programHeader.p_type, "Unknown"));
+		table.addDword("p_flags", programHeader.p_flags, "Flags");
+		table.addAddress("p_offset", programHeader.p_offset, "Offset of segment", elf);
+		table.addAddress("p_vaddr", programHeader.p_vaddr, "Virtual address of segment", elf);
+		table.addAddress("p_paddr", programHeader.p_paddr, "Physical address of segment", elf);
+		table.addAddress("p_filesz", programHeader.p_filesz, "Physical size of segment", elf);
+		table.addAddress("p_memsz", programHeader.p_memsz, "Virtual size of segment", elf);
+		table.addAddress("p_align", programHeader.p_align, programHeader.p_align <= 1 ? "No alignment" : "Has alignment", elf);
 	}
 
 	@Override

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ProgramHeaderDisplayMode.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/ProgramHeaderDisplayMode.java
@@ -30,6 +30,9 @@ public class ProgramHeaderDisplayMode implements ElfTableDisplayMode<ElfSegment>
 			put(0x6FFFFFFF, "PT_HIOS, reserved inclusive range");
 			put(0x70000000, "PT_LOPROC, reserved inclusive range");
 			put(0x7FFFFFFF, "PT_HIPROC, reserved inclusive range");
+			put(0x6474E550, "PT_GNU_EH_FRAME, location and size of exception info");
+			put(0x6474E551, "PT_GNU_STACK, permissions of stack segment");
+			put(0x6474E552, "PT_GNU_RELRO, location and size of relocated read-only segment");
 		}
 	};
 	private ElfFile elf;

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/SectionHeaderDisplayMode.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/elf/SectionHeaderDisplayMode.java
@@ -62,24 +62,24 @@ public class SectionHeaderDisplayMode implements ElfTableDisplayMode<ElfSectionH
 
 	@Override
 	public void apply(ElfSectionHeader programHeader, SizedDataTypeTable table) {
-		table.addDword("sh_name", programHeader.name_ndx, String.format("Offset to name (%s)", programHeader.getName()));
-		table.addDword("sh_type", programHeader.type, ST_MAP.getOrDefault(programHeader.type, "Unknown"));
-		table.addAddress("sh_flags", programHeader.flags, "", elf);
+		table.addDword("sh_name", programHeader.sh_name, String.format("Offset to name (%s)", programHeader.getName()));
+		table.addDword("sh_type", programHeader.sh_type, ST_MAP.getOrDefault(programHeader.sh_type, "Unknown"));
+		table.addAddress("sh_flags", programHeader.sh_flags, "", elf);
 
-		long sh_flags = programHeader.flags;
+		long sh_flags = programHeader.sh_flags;
 		SA_MAP.forEach((attributeValue, name) -> {
 			if ((sh_flags & attributeValue) > 0) {
 				table.addAddress("", attributeValue, name, elf);
 			}
 		});
 
-		table.addAddress("sh_addr", programHeader.address, "Virtual address of section", elf);
-		table.addAddress("sh_offset", programHeader.section_offset, "Section offset", elf);
-		table.addAddress("sh_size", programHeader.size, "Physical size of section", elf);
-		table.addDword("sh_link", programHeader.link, "Section index of associated section");
-		table.addDword("sh_info", programHeader.info, "Additional section information");
-		table.addAddress("sh_addralign", programHeader.address_alignment, "Alignment", elf);
-		table.addAddress("sh_entsize", programHeader.entry_size, "Size of each entry", elf);
+		table.addAddress("sh_addr", programHeader.sh_addr, "Virtual address of section", elf);
+		table.addAddress("sh_offset", programHeader.sh_offset, "Section offset", elf);
+		table.addAddress("sh_size", programHeader.sh_size, "Physical size of section", elf);
+		table.addDword("sh_link", programHeader.sh_link, "Section index of associated section");
+		table.addDword("sh_info", programHeader.sh_info, "Additional section information");
+		table.addAddress("sh_addralign", programHeader.sh_addralign, "Alignment", elf);
+		table.addAddress("sh_entsize", programHeader.sh_entsize, "Size of each entry", elf);
 	}
 
 	@Override

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/table/SizedDataTypeTable.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/table/SizedDataTypeTable.java
@@ -156,7 +156,7 @@ public class SizedDataTypeTable extends TableView<TableGeneric> {
 	 */
 	public void addAddress(String memberName, long value, String meaning, ElfFile elf) {
 		// ei_class 1 means 32-bit
-		if (elf.objectSize == 1) {
+		if (elf.ei_class == 1) {
 			getItems().add(new TableDword(memberName, (int) value, meaning));
 		} else {
 			getItems().add(new TableQword(memberName, value, meaning));


### PR DESCRIPTION
## What's new

* jelf is now updated to 0.7.0, field names are accurate to ELF specification now
* Fixed bug where selecting a section header would show information about the section header below it, not the actual current one
* Added support for PT_GNU_EH_FRAME, PT_GNU_STACK and PT_GNU_RELRO program header types