### PR TITLE
Fix improper syntax on comments

### DIFF
--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/Unmatched.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/Unmatched.java
@@ -17,7 +17,8 @@ public class Unmatched extends BaseElement implements CodeEntry {
 	}
 
 	/**
-	 * @param text Text to append.
+	 * @param text
+	 * 		Text to append.
 	 */
 	public void append(String text) {
 		raw += text;


### PR DESCRIPTION
Fixes a important typo.

## What's new

- Fixes a typo

## What's fixed

- Squashes the typo
