### PR TITLE
ContentSource refactoring

### DIFF
--- a/recaf-core/src/main/java/me/coley/recaf/util/Exporter.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/Exporter.java
@@ -83,6 +83,9 @@ public class Exporter {
 	 * 		Resource to add.
 	 */
 	public void addResource(Resource resource) {
+		// TODO: Support for cases where class name is not the intended target path
+		//   - war files with 'WEB-INF/classes/'
+
 		// Add files
 		if (!skipFiles) {
 			resource.getFiles().forEach((key, info) -> {

--- a/recaf-core/src/main/java/me/coley/recaf/util/visitor/ValidationClassReader.java
+++ b/recaf-core/src/main/java/me/coley/recaf/util/visitor/ValidationClassReader.java
@@ -68,6 +68,7 @@ public class ValidationClassReader extends ClassReader implements ConstantPoolCo
 
 	@Override
 	public String readUTF8(int offset, char[] charBuffer) {
+		// TODO: Something in this method makes us skip over later validation checks
 		boolean[] valid = this.valid;
 		if (valid == null) return super.readUTF8(offset, charBuffer);
 		if (offset == 0) return null;

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
@@ -54,6 +54,23 @@ public class ClassPatchingListener implements ContentSourceListener {
 			String patchPercent = String.format("%.2f", 100 * recoveredClasses / (double) invalidClasses);
 			logger.info("Recovered {}/{} ({}%) malformed classes", recoveredClasses, invalidClasses, patchPercent);
 		}
+		// Handle name mismatched classes
+		int mismatchedClasses = collection.getPendingNameMismatchedClasses().size();
+		collection.getPendingNameMismatchedClasses().entrySet().removeIf(entry -> {
+			ClassInfo info = entry.getValue();
+			String name = info.getName();
+			// If the name isn't already used we can just add it with the correct name.
+			if (!collection.getClasses().containsKey(name)) {
+				collection.addClass(info);
+				return true;
+			}
+			return false;
+		});
+		recoveredClasses = mismatchedClasses - collection.getPendingNameMismatchedClasses().size();
+		if (mismatchedClasses > 0) {
+			String patchPercent = String.format("%.2f", 100 * recoveredClasses / (double) mismatchedClasses);
+			logger.info("Recovered {}/{} ({}%) mismatched class names", recoveredClasses, mismatchedClasses, patchPercent);
+		}
 		// TODO: Other actionable items
 		//   - collection.getPendingDuplicateFiles()
 		//   - collection.getPendingDuplicateClasses()

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
@@ -6,19 +6,14 @@ import me.coley.cafedude.io.ClassFileReader;
 import me.coley.cafedude.io.ClassFileWriter;
 import me.coley.cafedude.transform.IllegalStrippingTransformer;
 import me.coley.recaf.code.ClassInfo;
-import me.coley.recaf.code.DexClassInfo;
 import me.coley.recaf.code.FileInfo;
-import me.coley.recaf.util.ByteHeaderUtil;
 import me.coley.recaf.util.logging.Logging;
-import me.coley.recaf.util.visitor.ValidationClassReader;
-import me.coley.recaf.util.visitor.ValidationVisitor;
+import me.coley.recaf.workspace.resource.source.ContentCollection;
 import me.coley.recaf.workspace.resource.source.ContentSourceListener;
 import org.slf4j.Logger;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * A content listener that uses CafeDude to patch an assortment of ASM crashing capabilities.
@@ -27,88 +22,59 @@ import java.util.List;
  */
 public class ClassPatchingListener implements ContentSourceListener {
 	private static final Logger logger = Logging.get(ClassPatchingListener.class);
-	private final List<FileInfo> invalidClasses = new ArrayList<>();
-	private final List<String> invalidEntryClassPaths = new ArrayList<>();
-	private final List<String> invalidEntryFilePaths = new ArrayList<>();
 
 	@Override
-	public void onFinishRead(Resource resource) {
-		if (invalidClasses.isEmpty())
-			return;
+	public void onFinishRead(ContentCollection collection) {
 		// Try to recover classes
-		int recovered = 0;
-		int count = invalidClasses.size();
-		logger.info("Attempting to patch {} malformed classes", count);
-		Iterator<FileInfo> iterator = invalidClasses.iterator();
-		while (iterator.hasNext()) {
-			FileInfo file = iterator.next();
-			String fileName = file.getName();
-			byte[] clazz = file.getValue();
-			// The class should match the known file header.
-			// If a class is packed or XOR'd we have no easy way to tell and automatically undo such an operation.
-			if (ByteHeaderUtil.match(clazz, ByteHeaderUtil.CLASS)) {
-				// Attempt to patch the class
-				try {
-					ClassFileReader reader = new ClassFileReader();
-					ClassFile classFile = reader.read(clazz);
-					new IllegalStrippingTransformer(classFile).transform();
-					clazz = new ClassFileWriter().write(classFile);
-				} catch (InvalidClassException ex) {
-					logger.error("CAFEDUDE failed to parse {}", fileName, ex);
-					continue;
-				}
-				// Check if it can be read by ASM and update the resource
-				try {
-					new ValidationClassReader(clazz).accept(new ValidationVisitor(), 0);
-					// If we reach here it can be read.
-					ClassInfo classInfo = ClassInfo.read(clazz);
-					resource.getFiles().remove(fileName);
-					resource.getClasses().put(classInfo.getName(), classInfo);
-					iterator.remove();
-					recovered++;
-				} catch (Exception ex) {
-					logger.error("ASM failed to parse patched class bytecode {}", fileName, ex);
-				}
-			} else {
-				logger.warn("{} does not start with 0xCAFEBABE", fileName);
+		int invalidClasses = collection.getPendingInvalidClasses().size();
+		collection.getPendingInvalidClasses().entrySet().removeIf(entry -> {
+			String path = entry.getKey();
+			byte[] data = entry.getValue();
+			try {
+				// Patch via CAFEDUDE
+				ClassFileReader reader = new ClassFileReader();
+				ClassFile classFile = reader.read(data);
+				new IllegalStrippingTransformer(classFile).transform();
+				byte[] patched = new ClassFileWriter().write(classFile);
+				// Attempt to load
+				ClassInfo info = ClassInfo.read(patched);
+				collection.addClass(info);
+				return true;
+			} catch (InvalidClassException ex) {
+				logger.error("CAFEDUDE failed to parse '{}'", path, ex);
+			} catch (Throwable t) {
+				logger.error("CAFEDUDE failed to patch '{}'", path, t);
 			}
+			// We failed to patch it, add as a file instead
+			collection.addFile(new FileInfo(path, data));
+			return false;
+		});
+		int recoveredClasses = invalidClasses - clearAndCountRemaining(collection.getPendingInvalidClasses());
+		if (invalidClasses > 0) {
+			String patchPercent = String.format("%.2f", 100 * recoveredClasses / (double) invalidClasses);
+			logger.info("Recovered {}/{} ({}%) malformed classes", recoveredClasses, invalidClasses, patchPercent);
 		}
-		String percent = String.format("%.2f", 100 * recovered / (double) count);
-		logger.info("Recovered {}/{} ({}%) malformed classes", recovered, count, percent);
-
-		if (!invalidEntryClassPaths.isEmpty() || !invalidEntryFilePaths.isEmpty()) {
-			count = invalidEntryClassPaths.size() + invalidEntryFilePaths.size();
-			logger.info("Pruning {} bogus entries ending in path separators", count);
-			invalidEntryClassPaths.forEach(key -> resource.getClasses().remove(key));
-			invalidEntryFilePaths.forEach(key -> resource.getFiles().remove(key));
-		}
+		// TODO: Other actionable items
+		//   - collection.getPendingDuplicateFiles()
+		//   - collection.getPendingDuplicateClasses()
+		//   - collection.getPendingNonClassClasses()
+		//   - collection.getPendingNameMismatchedClasses()
 	}
 
 	@Override
-	public void onInvalidClassEntry(FileInfo clazz) {
-		invalidClasses.add(clazz);
-	}
-
-	@Override
-	public void onClassEntry(ClassInfo clazz) {
-		if (clazz.getName().endsWith("/"))
-			invalidEntryClassPaths.add(clazz.getName());
-	}
-
-	@Override
-	public void onDexClassEntry(DexClassInfo clazz) {
-		if (clazz.getName().endsWith("/"))
-			invalidEntryClassPaths.add(clazz.getName());
-	}
-
-	@Override
-	public void onFileEntry(FileInfo file) {
-		if (file.getName().endsWith("/"))
-			invalidEntryFilePaths.add(file.getName());
-	}
-
-	@Override
-	public void onPreRead(Resource resource) {
+	public void onPreRead(ContentCollection collection) {
 		// no-op
+	}
+
+	private static int clearAndCountRemaining(Collection<?> collection) {
+		int count = collection.size();
+		collection.clear();
+		return count;
+	}
+
+	private static int clearAndCountRemaining(Map<?, ?> collection) {
+		int count = collection.size();
+		collection.clear();
+		return count;
 	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
@@ -111,14 +111,4 @@ public class ClassPatchingListener implements ContentSourceListener {
 	public void onPreRead(Resource resource) {
 		// no-op
 	}
-
-	@Override
-	public void onPreWrite(Resource resource, Path path) {
-		// no-op
-	}
-
-	@Override
-	public void onFinishWrite(Resource resource, Path path) {
-		// no-op
-	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/ClassPatchingListener.java
@@ -71,10 +71,14 @@ public class ClassPatchingListener implements ContentSourceListener {
 			String patchPercent = String.format("%.2f", 100 * recoveredClasses / (double) mismatchedClasses);
 			logger.info("Recovered {}/{} ({}%) mismatched class names", recoveredClasses, mismatchedClasses, patchPercent);
 		}
+		// Handle files named '.class' that aren't actual classes. Just add them as files.
+		collection.getPendingNonClassClasses().entrySet().removeIf(entry -> {
+			collection.addFile(new FileInfo(entry.getKey(), entry.getValue()));
+			return true;
+		});
 		// TODO: Other actionable items
 		//   - collection.getPendingDuplicateFiles()
 		//   - collection.getPendingDuplicateClasses()
-		//   - collection.getPendingNonClassClasses()
 		//   - collection.getPendingNameMismatchedClasses()
 	}
 

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/MultiDexClassMap.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/MultiDexClassMap.java
@@ -116,6 +116,18 @@ public class MultiDexClassMap implements Map<String, DexClassInfo> {
 	}
 
 	/**
+	 * Add a complete {@link DexClassMap}.
+	 *
+	 * @param dexName
+	 * 		Sub-dex map to add to.
+	 * @param map
+	 * 		Dex map.
+	 */
+	public void putDexMap(String dexName, DexClassMap map) {
+		backingMaps.put(dexName, map);
+	}
+
+	/**
 	 * Add a dex item to the map.
 	 *
 	 * @param dexName

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/Resource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/Resource.java
@@ -41,17 +41,6 @@ public class Resource {
 	}
 
 	/**
-	 * @param path
-	 * 		Path to write the contents of the resource to.
-	 *
-	 * @throws IOException
-	 * 		When the {@link #getContentSource() content source} write handler fails to write to the given path.
-	 */
-	public void write(Path path) throws IOException {
-		contentSource.writeTo(this, path);
-	}
-
-	/**
 	 * @return Collection of the classes contained by the resource.
 	 */
 	public ClassMap getClasses() {

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ApkContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ApkContentSource.java
@@ -1,25 +1,17 @@
 package me.coley.recaf.workspace.resource.source;
 
 import me.coley.recaf.code.DexClassInfo;
-import me.coley.recaf.workspace.resource.DexClassMap;
 import me.coley.recaf.code.FileInfo;
+import me.coley.recaf.workspace.resource.DexClassMap;
 import me.coley.recaf.workspace.resource.Resource;
 import org.jf.dexlib2.Opcodes;
 import org.jf.dexlib2.dexbacked.DexBackedClassDef;
 import org.jf.dexlib2.dexbacked.DexBackedDexFile;
-import org.jf.dexlib2.iface.ClassDef;
-import org.jf.dexlib2.writer.io.MemoryDataStore;
-import org.jf.dexlib2.writer.pool.DexPool;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Origin location information for apks.
@@ -55,11 +47,6 @@ public class ApkContentSource extends ArchiveFileContentSource {
 				} catch (IOException ex) {
 					logger.error("Failed parsing dex: " + name, ex);
 				}
-			} else if (name.endsWith(".arsc")) {
-				// TODO: arsc resource extraction
-				FileInfo file = new FileInfo(name, content);
-				getListeners().forEach(l -> l.onFileEntry(file));
-				resource.getFiles().initialPut(file);
 			} else {
 				FileInfo file = new FileInfo(name, content);
 				getListeners().forEach(l -> l.onFileEntry(file));
@@ -68,47 +55,5 @@ public class ApkContentSource extends ArchiveFileContentSource {
 		});
 		// Summarize what has been found
 		logger.info("Read {} classes, {} files", resource.getDexClasses().size(), resource.getFiles().size());
-	}
-
-	@Override
-	public void onWrite(Resource resource, Path path) throws IOException {
-		// Ensure parent directory exists
-		Path parentDir = path.getParent();
-		if (parentDir != null) {
-			Files.createDirectories(parentDir);
-		}
-		// Collect content to put into export directory
-		SortedMap<String, byte[]> outContent = new TreeMap<>();
-		resource.getFiles().forEach((fileName, fileInfo) ->
-				outContent.put(fileName, fileInfo.getValue()));
-		for (Map.Entry<String, DexClassMap> entry : resource.getDexClasses().getBackingMap().entrySet()) {
-			outContent.put(entry.getKey(), createDexFile(entry.getValue()));
-		}
-		// Log dirty classes
-		Set<String> dirtyDexClasses = resource.getDexClasses().getDirtyItems();
-		Set<String> dirtyFiles = resource.getFiles().getDirtyItems();
-		logger.info("Attempting to write {} classes, {} files to: {}",
-				resource.getClasses().size(), resource.getClasses().size(), path);
-		logger.info("{}/{} classes have been modified, {}/{} files have been modified",
-				resource.getClasses().size(), dirtyDexClasses.size(),
-				resource.getClasses().size(), dirtyFiles.size());
-		if (logger.isDebugEnabled()) {
-			dirtyDexClasses.forEach(name -> logger.debug("Dirty class: " + name));
-			dirtyFiles.forEach(name -> logger.debug("Dirty file: " + name));
-		}
-		// Write to file
-		long startTime = System.currentTimeMillis();
-		writeContent(path, outContent);
-		logger.info("Write complete, took {}ms", System.currentTimeMillis() - startTime);
-	}
-
-	private byte[] createDexFile(DexClassMap dexMap) throws IOException {
-		DexPool dexPool = new DexPool(dexMap.getOpcodes());
-		for (ClassDef def : dexMap.getClasses()) {
-			dexPool.internClass(def);
-		}
-		MemoryDataStore store = new MemoryDataStore();
-		dexPool.writeTo(store);
-		return store.getData();
 	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ClassContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ClassContentSource.java
@@ -1,9 +1,9 @@
 package me.coley.recaf.workspace.resource.source;
 
-import me.coley.recaf.util.IOUtil;
-import me.coley.recaf.util.logging.Logging;
 import me.coley.recaf.code.ClassInfo;
 import me.coley.recaf.code.FileInfo;
+import me.coley.recaf.util.IOUtil;
+import me.coley.recaf.util.logging.Logging;
 import me.coley.recaf.workspace.resource.Resource;
 import org.slf4j.Logger;
 
@@ -29,29 +29,11 @@ public class ClassContentSource extends FileContentSource {
 	}
 
 	@Override
-	public void onWrite(Resource resource, Path path) throws IOException {
-		if (resource.getClasses().size() > 1) {
-			throw new IllegalStateException("Resource was loaded from class, but now has multiple classes!");
-		}
-		// Ensure parent directory exists
-		Path parentDir = path.getParent();
-		if (parentDir != null) {
-			Files.createDirectories(parentDir);
-		}
-		// Write
-		logger.info("Attempting to class to: {}", path);
-		long startTime = System.currentTimeMillis();
-		ClassInfo classInfo = resource.getClasses().values().iterator().next();
-		Files.write(path, classInfo.getValue());
-		logger.info("Write complete, took {}ms", System.currentTimeMillis() - startTime);
-	}
-
-	@Override
 	protected void onRead(Resource resource) throws IOException {
 		byte[] content;
 		try (InputStream stream = Files.newInputStream(getPath())) {
 			content = IOUtil.toByteArray(stream);
-		} catch(Exception ex) {
+		} catch (Exception ex) {
 			throw new IOException("Failed to load class '" + getPath().getFileName() + "'", ex);
 		}
 		if (isParsableClass(content)) {

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContainerContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContainerContentSource.java
@@ -2,16 +2,12 @@ package me.coley.recaf.workspace.resource.source;
 
 import me.coley.recaf.code.ClassInfo;
 import me.coley.recaf.code.FileInfo;
-import me.coley.recaf.util.StringUtil;
 import me.coley.recaf.util.logging.Logging;
-import me.coley.recaf.workspace.resource.Resource;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 
 /**
  * Origin location information of container files <i>(jar, zip, war, directories)</i>.
@@ -22,79 +18,63 @@ import java.util.function.Predicate;
  * @author Matt Coley
  */
 public abstract class ContainerContentSource<E> extends FileContentSource {
-	protected final Logger logger = Logging.get(getClass());
-	private Predicate<E> entryFilter = createDefaultFilter();
+	private static final Logger logger = Logging.get(ContainerContentSource.class);
 
 	protected ContainerContentSource(SourceType type, Path path) {
 		super(type, path);
 	}
 
 	@Override
-	protected void onRead(Resource resource) throws IOException {
+	protected void onRead(ContentCollection collection) throws IOException {
 		logger.info("Reading from file: {}", getPath());
 		consumeEach((entry, content) -> {
 			String name = getPathName(entry);
+			// Skip if name contains zero-length directories
+			if (name.contains("//"))
+				return;
+			// Skip path traversal attempts
+			if (name.contains("../"))
+				return;
+			// Handle content
 			if (isClass(entry, content)) {
 				// Check if class can be parsed by ASM
 				try {
 					if (isParsableClass(content)) {
 						// Class can be parsed, record it as a class
 						ClassInfo clazz = ClassInfo.read(content);
-						// First make sure it has a path name that can be referenced at runtime.
-						// We want to intercept junk data, so we can optionally toss it.
-						String nameInPackage = StringUtil.shortenPath(clazz.getName());
-						if (nameInPackage.isEmpty()) {
-							// Alert the user via log call that something is amis
-							String loggedName = name;
-							if (loggedName.length() > 20)
-								loggedName = loggedName.substring(0, 20);
-							logger.warn("Adding unreferenceable class '{}' as a file instead", loggedName);
-							FileInfo file = new FileInfo(name, content);
-							resource.getFiles().initialPut(file);
+						String nameFromPath = name.substring(0, name.indexOf(".class"));
+						String nameFromClass = clazz.getName();
+						// Check if the name in the container does not match the actual class name.
+						if (!nameFromClass.equals(nameFromPath)) {
+							// Some obfuscators add impossible to reference classes, with names ending in package
+							// separator characters (example: 'com/foo/).
+							// These are typically used to confuse editors and hold no useful data.
+							collection.addMismatchedNameClass(nameFromPath, clazz);
 							return;
 						}
 						// Class is normal enough.
-						getListeners().forEach(l -> l.onClassEntry(clazz));
-						resource.getClasses().initialPut(clazz);
+						collection.addClass(clazz);
 					} else {
 						// Class cannot be parsed, record it as a file
 						int classExtIndex = name.lastIndexOf(".class");
-						if (classExtIndex != -1) {
+						if (classExtIndex != -1)
 							name = name.substring(0, classExtIndex);
-						}
-						name = filterInputClassName(name);
-						FileInfo clazz = new FileInfo(name + ".class", content);
-						getListeners().forEach(l -> l.onInvalidClassEntry(clazz));
-						resource.getFiles().initialPut(clazz);
+						collection.addInvalidClass(name, content);
 					}
 				} catch (Exception ex) {
 					logger.warn("Uncaught exception parsing class '{}' from input", name, ex);
 				}
-			} else {
-				FileInfo file = new FileInfo(name, content);
-				getListeners().forEach(l -> l.onFileEntry(file));
-				resource.getFiles().initialPut(file);
+			} else if (!name.endsWith("/")) {
+				// We can skip fake directory entries of non-classes.
+				// Now we just read for file contents.
+				if (name.endsWith(".class")) {
+					collection.addNonClassClass(name, content);
+				} else {
+					FileInfo file = new FileInfo(name, content);
+					collection.addFile(file);
+				}
 			}
 		});
-		// Summarize what has been found
-		logger.info("Read {} classes, {} files", resource.getClasses().size(), resource.getFiles().size());
-	}
-
-	/**
-	 * @param entryFilter
-	 * 		New entry filter.
-	 */
-	public void setEntryFilter(Predicate<E> entryFilter) {
-		this.entryFilter = Objects.requireNonNull(entryFilter);
-	}
-
-	/**
-	 * Determines what entries of the container are suitable for loading.
-	 *
-	 * @return Entry filter.
-	 */
-	public Predicate<E> getEntryFilter() {
-		return entryFilter;
 	}
 
 	/**
@@ -107,11 +87,6 @@ public abstract class ContainerContentSource<E> extends FileContentSource {
 	 * 		When the container cannot be read from, or when opening an entry stream fails.
 	 */
 	protected abstract void consumeEach(BiConsumer<E, byte[]> entryHandler) throws IOException;
-
-	/**
-	 * @return Default container filter.
-	 */
-	protected abstract Predicate<E> createDefaultFilter();
 
 	/**
 	 * Determines if the entry is supposedly a class. This is <b>NOT</b> a guarantee the file is a class that can be

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentCollection.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentCollection.java
@@ -1,0 +1,230 @@
+package me.coley.recaf.workspace.resource.source;
+
+import me.coley.recaf.code.ClassInfo;
+import me.coley.recaf.code.CommonClassInfo;
+import me.coley.recaf.code.DexClassInfo;
+import me.coley.recaf.code.FileInfo;
+import me.coley.recaf.workspace.resource.DexClassMap;
+import me.coley.recaf.workspace.resource.MultiDexClassMap;
+import me.coley.recaf.workspace.resource.Resource;
+import org.jf.dexlib2.Opcodes;
+import org.jf.dexlib2.iface.ClassDef;
+import org.jf.dexlib2.iface.DexFile;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Summary of data read from {@link ContentSource}.
+ * <br>
+ * Collects different categories of <i>"invalid"</i> input, allowing {@link ContentSourceListener} listeners
+ * to define custom handling. For an example see {@link me.coley.recaf.workspace.resource.ClassPatchingListener}.
+ *
+ * @author Matt Coley
+ */
+public class ContentCollection {
+	private final Resource resource;
+	private final Map<String, ClassInfo> classes = new HashMap<>();
+	private final MultiDexClassMap dexClasses = new MultiDexClassMap();
+	private final Map<String, FileInfo> files = new HashMap<>();
+	// Items that need to be acted on
+	private final List<ClassInfo> pendingDuplicateClasses = new ArrayList<>();
+	private final List<FileInfo> pendingDuplicateFiles = new ArrayList<>();
+	private final Map<String, ClassInfo> pendingNameMismatchedClasses = new HashMap<>();
+	private final Map<String, byte[]> pendingInvalidClasses = new HashMap<>();
+	private final Map<String, byte[]> pendingNonClassClasses = new HashMap<>();
+
+	/**
+	 * @param resource
+	 * 		Resource the content is for.
+	 */
+	public ContentCollection(Resource resource) {
+		this.resource = resource;
+	}
+
+	/**
+	 * @param info
+	 * 		Class to add.
+	 */
+	public void addClass(ClassInfo info) {
+		String name = info.getName();
+		if (classes.containsKey(name))
+			addDuplicateClass(info);
+		else
+			classes.put(name, info);
+	}
+
+	/**
+	 * @param dexPath
+	 * 		Path to dex file <i>(Internal to apk/zip)</i>.
+	 * @param dexFile
+	 * 		Dex file instance to pull classes from.
+	 */
+	public void addDexClasses(String dexPath, DexFile dexFile) {
+		Opcodes op = dexFile.getOpcodes();
+		DexClassMap dexClassMap = dexClasses.getBackingMap()
+				.computeIfAbsent(dexPath, k -> new DexClassMap(resource, op));
+		for (ClassDef dexClass : dexFile.getClasses()) {
+			DexClassInfo clazz = DexClassInfo.parse(dexPath, op, dexClass);
+			dexClassMap.put(clazz);
+		}
+	}
+
+	/**
+	 * Used when {@link #addClass(ClassInfo)} encounters a class name that already exists.
+	 *
+	 * @param info
+	 * 		Data with duplicate {@link CommonClassInfo#getName()}.
+	 */
+	private void addDuplicateClass(ClassInfo info) {
+		pendingDuplicateClasses.add(info);
+	}
+
+	/**
+	 * @param name
+	 * 		Path name to class.
+	 * @param info
+	 * 		Actual class info where {@link CommonClassInfo#getName()} does not match.
+	 */
+	public void addMismatchedNameClass(String name, ClassInfo info) {
+		pendingNameMismatchedClasses.put(name, info);
+	}
+
+	/**
+	 * Used when we encounter a class that is not able to be parsed with ASM.
+	 *
+	 * @param name
+	 * 		Path name to class.
+	 * @param data
+	 * 		Class bytecode.
+	 */
+	public void addInvalidClass(String name, byte[] data) {
+		pendingInvalidClasses.put(name, data);
+	}
+
+	/**
+	 * Used when we encounter a file that has a class extension, but does not have the correct file header.
+	 *
+	 * @param name
+	 * 		Path name to class.
+	 * @param data
+	 * 		Class bytecode.
+	 */
+	public void addNonClassClass(String name, byte[] data) {
+		pendingNonClassClasses.put(name, data);
+	}
+
+	/**
+	 * @param info
+	 * 		File to add.
+	 */
+	public void addFile(FileInfo info) {
+		String name = info.getName();
+		if (files.containsKey(name))
+			addDuplicateFile(info);
+		else
+			files.put(name, info);
+	}
+
+	/**
+	 * Used when {@link #addFile(FileInfo)} encounters a file name that already exists.
+	 *
+	 * @param info
+	 * 		Data with duplicate {@link FileInfo#getName()}.
+	 */
+	private void addDuplicateFile(FileInfo info) {
+		pendingDuplicateFiles.add(info);
+	}
+
+	/**
+	 * @return Classes found.
+	 */
+	public Map<String, ClassInfo> getClasses() {
+		return classes;
+	}
+
+	/**
+	 * @return Dex classes found.
+	 */
+	public MultiDexClassMap getDexClasses() {
+		return dexClasses;
+	}
+
+	/**
+	 * @return Files found.
+	 */
+	public Map<String, FileInfo> getFiles() {
+		return files;
+	}
+
+	/**
+	 * @return List of classes that already exist in {@link #getClasses()}
+	 * but other matching classes were found in the content source.
+	 */
+	public List<ClassInfo> getPendingDuplicateClasses() {
+		return pendingDuplicateClasses;
+	}
+
+	/**
+	 * @return List of files that already exist in {@link #getFiles()}
+	 * but other matching files were found in the content source.
+	 */
+	public List<FileInfo> getPendingDuplicateFiles() {
+		return pendingDuplicateFiles;
+	}
+
+	/**
+	 * @return Classes that could not be parsed by ASM.
+	 */
+	public Map<String, byte[]> getPendingInvalidClasses() {
+		return pendingInvalidClasses;
+	}
+
+	/**
+	 * @return Files that have {@code '.class'} in their path names, but do not contain actual classes.
+	 */
+	public Map<String, byte[]> getPendingNonClassClasses() {
+		return pendingNonClassClasses;
+	}
+
+	/**
+	 * @return Classes that do not match their path names.
+	 */
+	public Map<String, ClassInfo> getPendingNameMismatchedClasses() {
+		return pendingNameMismatchedClasses;
+	}
+
+	/**
+	 * @return Number of classes read.
+	 */
+	public int getClassCount() {
+		return getClasses().size();
+	}
+
+	/**
+	 * @return Number of dex classes read.
+	 */
+	public int getDexClassCount() {
+		return getDexClasses().size();
+	}
+
+	/**
+	 * @return Number of files read.
+	 */
+	public int getFileCount() {
+		return getFiles().size();
+	}
+
+	/**
+	 * @return Number of items with pending actions to take.
+	 */
+	public int getPendingCount() {
+		return pendingDuplicateClasses.size() +
+				pendingDuplicateFiles.size() +
+				pendingInvalidClasses.size() +
+				pendingNonClassClasses.size() +
+				pendingNameMismatchedClasses.size();
+	}
+}

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSource.java
@@ -3,7 +3,6 @@ package me.coley.recaf.workspace.resource.source;
 import me.coley.recaf.workspace.resource.Resource;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -57,37 +56,6 @@ public abstract class ContentSource {
 		onRead(resource);
 		getListeners().forEach(l -> l.onFinishRead(resource));
 	}
-
-	/**
-	 * Writes the content of the given resource to the given path.
-	 * Each source implementation may handle content differently based on the expectation of how it was loaded.
-	 *
-	 * @param resource
-	 * 		Resource with content to write.
-	 * @param path
-	 * 		Path to write to.
-	 *
-	 * @throws IOException
-	 * 		When writing to the given path fails.
-	 */
-	public void writeTo(Resource resource, Path path) throws IOException {
-		getListeners().forEach(l -> l.onPreWrite(resource, path));
-		onWrite(resource, path);
-		getListeners().forEach(l -> l.onFinishWrite(resource, path));
-	}
-
-	/**
-	 * Writes the content of the given resource to the given path.
-	 *
-	 * @param resource
-	 * 		Resource with content to write.
-	 * @param path
-	 * 		Path to write to.
-	 *
-	 * @throws IOException
-	 * 		When writing to the given path fails.
-	 */
-	protected abstract void onWrite(Resource resource, Path path) throws IOException;
 
 	/**
 	 * Reads classes and files from the source and deposits them into the given resource.

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSource.java
@@ -1,6 +1,8 @@
 package me.coley.recaf.workspace.resource.source;
 
+import me.coley.recaf.util.logging.Logging;
 import me.coley.recaf.workspace.resource.Resource;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -12,6 +14,7 @@ import java.util.Set;
  * @author Matt Coley
  */
 public abstract class ContentSource {
+	private static final Logger logger = Logging.get(ContentSource.class);
 	private final Set<ContentSourceListener> listeners = new HashSet<>();
 	private final SourceType type;
 
@@ -52,21 +55,44 @@ public abstract class ContentSource {
 	 * 		When reading from the source encounters some error.
 	 */
 	public void readInto(Resource resource) throws IOException {
-		getListeners().forEach(l -> l.onPreRead(resource));
-		onRead(resource);
-		getListeners().forEach(l -> l.onFinishRead(resource));
+		ContentCollection collection = new ContentCollection(resource);
+		getListeners().forEach(l -> l.onPreRead(collection));
+		onRead(collection);
+		getListeners().forEach(l -> l.onFinishRead(collection));
+		// Log results / summarize what has been found
+		int actionable = collection.getPendingCount();
+		if (actionable > 0) {
+			logger.info("Read {} classes, {} files, {} actionable items",
+					collection.getClassCount() + collection.getDexClassCount(),
+					collection.getFileCount(),
+					collection.getPendingCount());
+		} else {
+			logger.info("Read {} classes, {} files",
+					collection.getClassCount() + collection.getDexClassCount(),
+					collection.getFileCount());
+		}
+		// Populate
+		collection.getFiles().forEach((path, info) -> {
+			resource.getFiles().initialPut(info);
+		});
+		collection.getClasses().forEach((path, info) -> {
+			resource.getClasses().initialPut(info);
+		});
+		collection.getDexClasses().getBackingMap().forEach((path, map) -> {
+			resource.getDexClasses().putDexMap(path, map);
+		});
 	}
 
 	/**
 	 * Reads classes and files from the source and deposits them into the given resource.
 	 *
-	 * @param resource
+	 * @param collection
 	 * 		Destination.
 	 *
 	 * @throws IOException
 	 * 		When reading from the source encounters some error.
 	 */
-	protected abstract void onRead(Resource resource) throws IOException;
+	protected abstract void onRead(ContentCollection collection) throws IOException;
 
 	/**
 	 * @return Content source type.

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSourceListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSourceListener.java
@@ -32,28 +32,6 @@ public interface ContentSourceListener {
 	void onFinishRead(Resource resource);
 
 	/**
-	 * Called before {@link ContentSource#onWrite(Resource, Path)} is invoked.
-	 * Any pre-processing steps can be done here.
-	 *
-	 * @param resource
-	 * 		Content.
-	 * @param path
-	 * 		Destination.
-	 */
-	void onPreWrite(Resource resource, Path path);
-
-	/**
-	 * Called after {@link ContentSource#onWrite(Resource, Path)}} completes.
-	 * Any cleanup steps can be done here.
-	 *
-	 * @param resource
-	 * 		Content.
-	 * @param path
-	 * 		Destination
-	 */
-	void onFinishWrite(Resource resource, Path path);
-
-	/**
 	 * Called right before the given class is loaded into the associated {@link Resource}.
 	 *
 	 * @param clazz

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSourceListener.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/ContentSourceListener.java
@@ -1,11 +1,6 @@
 package me.coley.recaf.workspace.resource.source;
 
-import me.coley.recaf.code.ClassInfo;
-import me.coley.recaf.code.DexClassInfo;
-import me.coley.recaf.code.FileInfo;
 import me.coley.recaf.workspace.resource.Resource;
-
-import java.nio.file.Path;
 
 /**
  * Listener for read/write operations of a {@link ContentSource}.
@@ -14,54 +9,20 @@ import java.nio.file.Path;
  */
 public interface ContentSourceListener {
 	/**
-	 * Called before {@link ContentSource#onRead(Resource)} is invoked.
+	 * Called before {@link ContentSource#readInto(Resource)} is invoked.
 	 * Any pre-processing steps can be done here.
 	 *
-	 * @param resource
+	 * @param collection
 	 * 		Destination.
 	 */
-	void onPreRead(Resource resource);
+	void onPreRead(ContentCollection collection);
 
 	/**
-	 * Called after {@link ContentSource#onRead(Resource)} completes.
+	 * Called after {@link ContentSource#readInto(Resource)} completes.
 	 * Any cleanup steps can be done here.
 	 *
-	 * @param resource
+	 * @param collection
 	 * 		Destination.
 	 */
-	void onFinishRead(Resource resource);
-
-	/**
-	 * Called right before the given class is loaded into the associated {@link Resource}.
-	 *
-	 * @param clazz
-	 * 		Class loaded.
-	 */
-	void onClassEntry(ClassInfo clazz);
-
-	/**
-	 * Called right before the given android class is loaded into the associated {@link Resource}.
-	 *
-	 * @param clazz
-	 * 		Class loaded.
-	 */
-	void onDexClassEntry(DexClassInfo clazz);
-
-	/**
-	 * Called right before the given class is loaded into the associated {@link Resource} as a file.
-	 * This indicates the class likely is obfuscated with an ASM crasher,
-	 * or the file extension says class but the file content is not actually a valid class.
-	 *
-	 * @param clazz
-	 * 		Class loaded.
-	 */
-	void onInvalidClassEntry(FileInfo clazz);
-
-	/**
-	 * Called right before the given file is loaded into the associated {@link Resource}.
-	 *
-	 * @param file
-	 * 		File loaded.
-	 */
-	void onFileEntry(FileInfo file);
+	void onFinishRead(ContentCollection collection);
 }

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/DirectoryContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/DirectoryContentSource.java
@@ -9,8 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Map;
-import java.util.SortedMap;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
@@ -29,21 +27,9 @@ public class DirectoryContentSource extends ContainerContentSource<Path> {
 	}
 
 	@Override
-	protected void writeContent(Path output, SortedMap<String, byte[]> content) throws IOException {
-		for (Map.Entry<String, byte[]> entry : content.entrySet()) {
-			String name = entry.getKey();
-			byte[] out = entry.getValue();
-			Path path = output.resolve(name);
-			Files.createDirectories(path.getParent());
-			Files.write(path, out);
-		}
-	}
-
-	@Override
 	protected void consumeEach(BiConsumer<Path, byte[]> entryHandler) throws IOException {
 		Predicate<Path> predicate = getEntryFilter();
-		Files.walkFileTree(getPath(), new SimpleFileVisitor<Path>() {
-
+		Files.walkFileTree(getPath(), new SimpleFileVisitor<>() {
 			private final byte[] buffer = IOUtil.newByteBuffer();
 
 			@Override

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/EmptyContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/EmptyContentSource.java
@@ -22,9 +22,4 @@ public class EmptyContentSource extends ContentSource {
 	protected void onRead(Resource resource) throws IOException {
 		// no-op
 	}
-
-	@Override
-	public void onWrite(Resource resource, Path path) throws IOException {
-		// no-op
-	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/EmptyContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/EmptyContentSource.java
@@ -1,9 +1,6 @@
 package me.coley.recaf.workspace.resource.source;
 
-import me.coley.recaf.workspace.resource.Resource;
-
 import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * Dummy content source that will provide no data.
@@ -19,7 +16,7 @@ public class EmptyContentSource extends ContentSource {
 	}
 
 	@Override
-	protected void onRead(Resource resource) throws IOException {
+	protected void onRead(ContentCollection collection) throws IOException {
 		// no-op
 	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/FileContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/FileContentSource.java
@@ -28,18 +28,6 @@ public abstract class FileContentSource extends ContentSource {
 	}
 
 	/**
-	 * Allow modification of the output class name.
-	 *
-	 * @param className
-	 * 		Original class name.
-	 *
-	 * @return Path in archive output.
-	 */
-	protected String filterOutputClassName(String className) {
-		return className;
-	}
-
-	/**
 	 * Allow modification of the input class name when it can't be found normally.
 	 *
 	 * @param className

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/FileContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/FileContentSource.java
@@ -1,9 +1,8 @@
 package me.coley.recaf.workspace.resource.source;
 
 import me.coley.recaf.util.ByteHeaderUtil;
-import me.coley.recaf.util.visitor.ValidationClassReader;
-import me.coley.recaf.util.visitor.ValidationVisitor;
 import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
 
 import java.nio.file.Path;
 
@@ -28,18 +27,6 @@ public abstract class FileContentSource extends ContentSource {
 	}
 
 	/**
-	 * Allow modification of the input class name when it can't be found normally.
-	 *
-	 * @param className
-	 * 		Original class name.
-	 *
-	 * @return Path to use in resource.
-	 */
-	protected String filterInputClassName(String className) {
-		return className;
-	}
-
-	/**
 	 * Check if the class can be parsed by ASM.
 	 *
 	 * @param content
@@ -49,7 +36,7 @@ public abstract class FileContentSource extends ContentSource {
 	 */
 	protected static boolean isParsableClass(byte[] content) {
 		try {
-			new ValidationClassReader(content).accept(new ValidationVisitor(), 0);
+			new ClassReader(content).accept(new ClassWriter(0), 0);
 			return true;
 		} catch (Exception ex) {
 			return false;

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/MavenContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/MavenContentSource.java
@@ -65,12 +65,6 @@ public class MavenContentSource extends ContentSource {
 	}
 
 	@Override
-	public void onWrite(Resource resource, Path path) throws IOException {
-		// Redirect to Jar content's write implementation
-		new JarContentSource(null).writeTo(resource, path);
-	}
-
-	@Override
 	protected void onRead(Resource resource) throws IOException {
 		Path local = getLocalArtifactPath(NO_SUFFIX);
 		// Check if we need to download the artifact

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/MavenContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/MavenContentSource.java
@@ -2,7 +2,6 @@ package me.coley.recaf.workspace.resource.source;
 
 import me.coley.recaf.util.IOUtil;
 import me.coley.recaf.util.logging.Logging;
-import me.coley.recaf.workspace.resource.Resource;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 
@@ -65,7 +64,7 @@ public class MavenContentSource extends ContentSource {
 	}
 
 	@Override
-	protected void onRead(Resource resource) throws IOException {
+	protected void onRead(ContentCollection collection) throws IOException {
 		Path local = getLocalArtifactPath(NO_SUFFIX);
 		// Check if we need to download the artifact
 		if (!Files.isReadable(local)) {
@@ -78,7 +77,7 @@ public class MavenContentSource extends ContentSource {
 		}
 		// Load from local file
 		logger.info("Reading from maven artifact jar: {}", local);
-		new JarContentSource(local).readInto(resource);
+		new JarContentSource(local).onRead(collection);
 	}
 
 	/**

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/UrlContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/UrlContentSource.java
@@ -35,27 +35,6 @@ public class UrlContentSource extends ContentSource {
 	}
 
 	@Override
-	public void onWrite(Resource resource, Path path) throws IOException {
-		logger.debug("Redirecting write for URL source to type: {}", backingType.name());
-		switch (backingType) {
-			case CLASS:
-				new ClassContentSource(null).writeTo(resource, path);
-				break;
-			case JAR:
-				new JarContentSource(null).writeTo(resource, path);
-				break;
-			case WAR:
-				new WarContentSource(null).writeTo(resource, path);
-				break;
-			case ZIP:
-				new ZipContentSource(null).writeTo(resource, path);
-				break;
-			default:
-				throw new IllegalStateException("Unsupported backing type for URL content source");
-		}
-	}
-
-	@Override
 	protected void onRead(Resource resource) throws IOException {
 		boolean isLocal = urlText.startsWith("file:");
 		URL url = new URL(urlText);

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/UrlContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/UrlContentSource.java
@@ -2,7 +2,6 @@ package me.coley.recaf.workspace.resource.source;
 
 import me.coley.recaf.util.IOUtil;
 import me.coley.recaf.util.logging.Logging;
-import me.coley.recaf.workspace.resource.Resource;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -35,7 +34,7 @@ public class UrlContentSource extends ContentSource {
 	}
 
 	@Override
-	protected void onRead(Resource resource) throws IOException {
+	protected void onRead(ContentCollection collection) throws IOException {
 		boolean isLocal = urlText.startsWith("file:");
 		URL url = new URL(urlText);
 		Path path;
@@ -57,16 +56,16 @@ public class UrlContentSource extends ContentSource {
 		logger.info("Parsing temporary file with backing content source type: {}", backingType.name());
 		switch (backingType) {
 			case CLASS:
-				new ClassContentSource(path).onRead(resource);
+				new ClassContentSource(path).onRead(collection);
 				break;
 			case JAR:
-				new JarContentSource(path).onRead(resource);
+				new JarContentSource(path).onRead(collection);
 				break;
 			case WAR:
-				new WarContentSource(path).onRead(resource);
+				new WarContentSource(path).onRead(collection);
 				break;
 			case ZIP:
-				new ZipContentSource(path).onRead(resource);
+				new ZipContentSource(path).onRead(collection);
 				break;
 			default:
 				throw new IllegalStateException("Unsupported backing type for URL content source");

--- a/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/WarContentSource.java
+++ b/recaf-core/src/main/java/me/coley/recaf/workspace/resource/source/WarContentSource.java
@@ -19,11 +19,6 @@ public class WarContentSource extends ArchiveFileContentSource {
 	}
 
 	@Override
-	protected String filterOutputClassName(String className) {
-		return WAR_CLASS_PREFIX + className;
-	}
-
-	@Override
 	protected String filterInputClassName(String className) {
 		if (className.startsWith(WAR_CLASS_PREFIX)) {
 			return className.substring(WAR_CLASS_PREFIX.length());


### PR DESCRIPTION
## What's new

`ContentSource#onRead` no longer directly dumps classes/files into `Resource` instances. Instead it puts them into a `ContentCollection` instance. This class has fields for:

* normal classes/files
* various obfuscated/illegal input 

The `ContentSourceListener` has been repurposed to only have a `pre` and `post` operation, where `post` can be used to handle the illegal input. 

---------

At the moment not all forms of illegal input are handled in the UI. The end goal would be to prompt users what they would like to do with different kinds of input if there are conflicts. For most inputs this shouldn't affect end-users dropping in normal jar files and stuff.