### PR TITLE
Added optional description tooltips to config values

### DIFF
--- a/recaf-ui/src/main/java/me/coley/recaf/ui/pane/ConfigPane.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/pane/ConfigPane.java
@@ -10,8 +10,10 @@ import javafx.scene.control.*;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
+import javafx.stage.PopupWindow;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+import javafx.util.Duration;
 import me.coley.recaf.config.ConfigContainer;
 import me.coley.recaf.config.ConfigID;
 import me.coley.recaf.config.Configs;
@@ -113,12 +115,23 @@ public class ConfigPane extends BorderPane implements WindowShownListener {
 				ConfigID id = field.getAnnotation(ConfigID.class);
 				String idKey = groupKey + '.' + id.value();
 				Node editor = getConfigComponent(container, field, idKey);
+				Node tooltipElement = editor;
 				if (editor instanceof Unlabeled) {
 					Label editorLabel = new BoundLabel(Lang.getBinding(idKey));
 					content.add(editorLabel, 1, i, 1, 1);
 					content.add(editor, 2, i, 1, 1);
+					tooltipElement = editorLabel;
 				} else {
 					content.add(editor, 1, i, 2, 1);
+				}
+				if(Lang.has(idKey + ".description")) { // check if a description translation is available
+					// if there is, create a tooltip for the element
+					Tooltip tooltip = new Tooltip(Lang.get(idKey + ".description"));
+					tooltip.setGraphic(Icons.getIconView(Icons.INFO));
+					tooltip.setShowDelay(Duration.ZERO);
+					tooltip.setHideDelay(Duration.ZERO);
+					tooltip.setAutoHide(false);
+					Tooltip.install(tooltipElement, tooltip);
 				}
 				i++;
 			}

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/util/Lang.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/util/Lang.java
@@ -271,6 +271,27 @@ public class Lang {
 	}
 
 	/**
+	 * @param translations
+	 * 		Language translations group to load from.
+	 * @param translationKey
+	 * 		Key name.
+	 * @return If the translation is present in the given translations.
+	 */
+	public static boolean has(String translations, String translationKey) {
+		Map<String, String> map = Lang.translations.getOrDefault(translations, currentTranslationMap);
+		return map.containsKey(translationKey);
+	}
+
+	/**
+	 * @param translationKey
+	 * 		Key name.
+	 * @return If the translation is present in the current translations.
+	 */
+	public static boolean has(String translationKey) {
+		return has(getCurrentTranslations(), translationKey);
+	}
+
+	/**
 	 * Load the translations and initialize the default one.
 	 */
 	public static void initialize() {


### PR DESCRIPTION
## What's new

- Added optional tooltips to config values using the translation key `[conf.[id].description]`
![Preview](https://user-images.githubusercontent.com/55301990/175776447-91dfb480-ea5b-4b33-a914-50e8237a1094.png)
