### PR TITLE
Fix ComboBox translation not updating when changing language

### DIFF
--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/EnumComboBox.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/EnumComboBox.java
@@ -32,10 +32,20 @@ public class EnumComboBox<E extends Enum<?>> extends ComboBox<E> {
 				}
 
 				@Override
+				protected void onInvalidating() {
+					super.onInvalidating();
+
+					setItems(FXCollections.observableArrayList(type.getEnumConstants()));
+				}
+
+				@Override
 				protected StringConverter<E> computeValue() {
 					return new StringConverter<>() {
 						@Override
 						public String toString(E object) {
+							if (object == null)
+								return "";
+
 							return Lang.get(((Translatable) object).getTranslationKey());
 						}
 

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/EnumComboBox.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/EnumComboBox.java
@@ -33,8 +33,8 @@ public class EnumComboBox<E extends Enum<?>> extends ComboBox<E> {
 
 				@Override
 				protected void onInvalidating() {
-					super.onInvalidating();
-
+					// Hack to force refresh the translation bindings.
+					// Needs to be a new list, cannot be the same instance as before.
 					setItems(FXCollections.observableArrayList(type.getEnumConstants()));
 				}
 
@@ -45,7 +45,6 @@ public class EnumComboBox<E extends Enum<?>> extends ComboBox<E> {
 						public String toString(E object) {
 							if (object == null)
 								return "";
-
 							return Lang.get(((Translatable) object).getTranslationKey());
 						}
 

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/config/ConfigEnum.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/config/ConfigEnum.java
@@ -1,10 +1,8 @@
 package me.coley.recaf.ui.control.config;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.scene.control.ComboBox;
 import javafx.scene.control.SingleSelectionModel;
 import me.coley.recaf.config.ConfigContainer;
+import me.coley.recaf.ui.control.EnumComboBox;
 import me.coley.recaf.util.ReflectUtil;
 
 import java.lang.reflect.Field;
@@ -15,7 +13,7 @@ import java.lang.reflect.Field;
  * @author Wolfie / win32kbase
  * @author Matt Coley
  */
-public class ConfigEnum extends ComboBox<Enum<?>> implements Unlabeled {
+public class ConfigEnum extends EnumComboBox<Enum<?>> implements Unlabeled {
 	/**
 	 * @param instance
 	 * 		Config container.
@@ -24,16 +22,10 @@ public class ConfigEnum extends ComboBox<Enum<?>> implements Unlabeled {
 	 */
 	@SuppressWarnings("unchecked")
 	public ConfigEnum(ConfigContainer instance, Field field) {
-		// Wrap constants to list
-		ObservableList<Enum<?>> objects = (ObservableList<Enum<?>>)
-				FXCollections.observableArrayList(field.getType().getEnumConstants());
-		setItems(objects);
+		super((Class<Enum<?>>) field.getType(), ReflectUtil.quietGet(instance, field));
 		// Register selection updates --> field setting
-		// and select the current value.
 		SingleSelectionModel<Enum<?>> selectionModel = getSelectionModel();
 		selectionModel.selectedItemProperty().addListener((observable, oldValue, newValue) ->
 				ReflectUtil.quietSet(instance, field, newValue));
-		Enum<?> current = ReflectUtil.quietGet(instance, field);
-		getSelectionModel().select(current);
 	}
 }


### PR DESCRIPTION
## What's fixed

This fixes combo boxes not updating when changing the language in the settings. The previous change introduced in c30b21c177a01dca2fcc78e85d127b5fd1adb070 seems to be ineffective. The fix is still a bit of a hack, but I couldn't find a better way to force the combo box to refresh without messing with the associated skin.
Before:
![before](https://user-images.githubusercontent.com/36999320/182042812-8f2d9fac-957d-4cd1-b2af-4f053b7f9b8e.gif)
After
![after](https://user-images.githubusercontent.com/36999320/182042758-a2dbd58e-1c8c-4f51-a511-b39fdffce521.gif)
: