### PR TITLE
Introduce "itf" suffix to invokestatic calls

### DIFF
--- a/src/main/java/me/coley/recaf/parse/bytecode/Disassembler.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/Disassembler.java
@@ -297,6 +297,9 @@ public class Disassembler {
 		String name = EscapeUtil.escapeCommon(insn.name);
 		String desc = EscapeUtil.escapeCommon(insn.desc);
 		line.append(' ').append(owner).append('.').append(name).append(desc);
+		if (insn.getOpcode() == Opcodes.INVOKESTATIC && insn.itf) {
+			line.append(" itf");
+		}
 	}
 
 	private void visitJumpInsn(StringBuilder line, JumpInsnNode insn) {

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/ItfAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/ItfAST.java
@@ -1,0 +1,16 @@
+package me.coley.recaf.parse.bytecode.ast;
+
+public class ItfAST extends AST {
+	/**
+	 * @param line  Line number this node is written on.
+	 * @param start Offset from line start this node starts at.
+	 */
+	public ItfAST(int line, int start) {
+		super(line, start);
+	}
+
+	@Override
+	public String print() {
+		return "itf";
+	}
+}

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/ItfAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/ItfAST.java
@@ -1,5 +1,10 @@
 package me.coley.recaf.parse.bytecode.ast;
 
+/**
+ * Itf AST for static interface method invocations.
+ *
+ * @author Earthcomputer
+ */
 public class ItfAST extends AST {
 	/**
 	 * @param line  Line number this node is written on.

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/MethodInsnAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/MethodInsnAST.java
@@ -85,6 +85,9 @@ public class MethodInsnAST extends InsnAST {
 		return desc;
 	}
 
+	/**
+	 * @return Itf AST for static invocations of interface methods.
+	 */
 	public ItfAST getItf() {
 		return itf;
 	}

--- a/src/main/java/me/coley/recaf/parse/bytecode/ast/MethodInsnAST.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/ast/MethodInsnAST.java
@@ -2,6 +2,7 @@ package me.coley.recaf.parse.bytecode.ast;
 
 import me.coley.recaf.parse.bytecode.MethodCompilation;
 import me.coley.recaf.parse.bytecode.exception.AssemblerException;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
 
 /**
@@ -13,6 +14,7 @@ public class MethodInsnAST extends InsnAST {
 	private final TypeAST owner;
 	private final NameAST name;
 	private final DescAST desc;
+	private final ItfAST itf;
 
 	/**
 	 * @param line
@@ -29,13 +31,37 @@ public class MethodInsnAST extends InsnAST {
 	 * 		Method descriptor AST.
 	 */
 	public MethodInsnAST(int line, int start, OpcodeAST opcode, TypeAST owner, NameAST name, DescAST desc) {
+		this(line, start, opcode, owner, name, desc, null);
+	}
+
+	/**
+	 * @param line
+	 * 		Line number this node is written on.
+	 * @param start
+	 * 		Offset from line start this node starts at.
+	 * @param opcode
+	 * 		Opcode AST.
+	 * @param owner
+	 * 		Method owner type AST.
+	 * @param name
+	 * 		Method name AST.
+	 * @param desc
+	 * 		Method descriptor AST.
+	 * @param itf
+	 *      Present on invokestatic if this is an interface method ref
+	 */
+	public MethodInsnAST(int line, int start, OpcodeAST opcode, TypeAST owner, NameAST name, DescAST desc, ItfAST itf) {
 		super(line, start, opcode);
 		this.owner = owner;
 		this.name = name;
 		this.desc = desc;
+		this.itf = itf;
 		addChild(owner);
 		addChild(name);
 		addChild(desc);
+		if (itf != null) {
+			addChild(itf);
+		}
 	}
 
 	/**
@@ -59,14 +85,28 @@ public class MethodInsnAST extends InsnAST {
 		return desc;
 	}
 
+	public ItfAST getItf() {
+		return itf;
+	}
+
 	@Override
 	public String print() {
-		return getOpcode().print() + " " + owner.print() + "." + name.print() + desc.print();
+		String ret = getOpcode().print() + " " + owner.print() + "." + name.print() + desc.print();
+		if (itf != null) {
+			ret += " " + itf.print();
+		}
+		return ret;
 	}
 
 	@Override
 	public void compile(MethodCompilation compilation) throws AssemblerException {
-		compilation.addInstruction(new MethodInsnNode(getOpcode().getOpcode(), getOwner().getType(),
-				getName().getName(), getDesc().getDesc()), this);
+		int opcode = getOpcode().getOpcode();
+		if (opcode == Opcodes.INVOKESTATIC) {
+			compilation.addInstruction(new MethodInsnNode(opcode, getOwner().getType(),
+					getName().getName(), getDesc().getDesc(), itf != null), this);
+		} else {
+			compilation.addInstruction(new MethodInsnNode(opcode, getOwner().getType(),
+					getName().getName(), getDesc().getDesc()), this);
+		}
 	}
 }

--- a/src/test/java/me/coley/recaf/AssemblyAstTest.java
+++ b/src/test/java/me/coley/recaf/AssemblyAstTest.java
@@ -282,6 +282,30 @@ public class AssemblyAstTest {
 		}
 
 		@Test
+		public void testMethodInsnInvokeStatic() {
+			String text = "INVOKESTATIC java/lang/System.exit(I)V";
+			MethodInsnAST methodAST = single(text);
+			assertEquals(text, methodAST.print());
+			assertEquals("INVOKESTATIC", methodAST.getOpcode().print());
+			assertEquals("java/lang/System", methodAST.getOwner().getType());
+			assertEquals("exit", methodAST.getName().getName());
+			assertEquals("(I)V", methodAST.getDesc().getDesc());
+			assertNull(methodAST.getItf());
+		}
+
+		@Test
+		public void testMethodInsnInvokeStaticItf() {
+			String text = "INVOKESTATIC java/util/function/Function.identity()Ljava/util/function/Function; itf";
+			MethodInsnAST methodAST = single(text);
+			assertEquals(text, methodAST.print());
+			assertEquals("INVOKESTATIC", methodAST.getOpcode().print());
+			assertEquals("java/util/function/Function", methodAST.getOwner().getType());
+			assertEquals("identity", methodAST.getName().getName());
+			assertEquals("()Ljava/util/function/Function;", methodAST.getDesc().getDesc());
+			assertNotNull(methodAST.getItf());
+		}
+
+		@Test
 		public void testLdcInsn() {
 			// int
 			String text = "LDC 1";
@@ -510,6 +534,15 @@ public class AssemblyAstTest {
 		public void testMemberSuggestFromMethod() {
 			List<String> suggestions = suggest(null, "INVOKESTATIC java/io/PrintStream.printl");
 			assertTrue(suggestions.contains("println(Ljava/lang/String;)V"));
+		}
+
+		@Test
+		public void testItfSuggest() {
+			List<String> suggestions = suggest(null, "INVOKESTATIC java/util/function/Function.identity()Ljava/util/function/Function; i");
+			assertTrue(suggestions.contains("itf"));
+			//
+			suggestions = suggest(null, "INVOKEVIRTUAL java/io/PrintStream.println i");
+			assertFalse(suggestions.contains("itf"));
 		}
 
 		@Test

--- a/src/test/java/me/coley/recaf/AssemblyCasesTest.java
+++ b/src/test/java/me/coley/recaf/AssemblyCasesTest.java
@@ -8,6 +8,7 @@ import me.coley.recaf.parse.bytecode.exception.AssemblerException;
 import me.coley.recaf.parse.bytecode.exception.VerifierException;
 import me.coley.recaf.workspace.LazyClasspathResource;
 import org.junit.jupiter.api.*;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.*;
 import org.objectweb.asm.tree.analysis.Frame;
 
@@ -686,6 +687,21 @@ public class AssemblyCasesTest {
 			assertNotEquals(initial, retFrameLocal.getValue());
 			assertNotEquals(one, retFrameLocal.getValue());
 			assertEquals(two, retFrameLocal.getValue());
+		}
+
+		@Test
+		public void testInterfaceMethodRef() {
+			try {
+				MethodNode method = compile(parse(
+						"INVOKESTATIC java/util/function/Function.identity()Ljava/util/function/Function; itf\n" +
+							"POP\n" +
+							"RETURN"));
+				AbstractInsnNode invokeStaticInsn = method.instructions.get(1);
+				assertEquals(Opcodes.INVOKESTATIC, invokeStaticInsn.getOpcode());
+				assertTrue(((MethodInsnNode) invokeStaticInsn).itf, "INVOKESTATIC instruction must have itf=true");
+			} catch (AssemblerException ex) {
+				fail(ex);
+			}
 		}
 	}
 


### PR DESCRIPTION
## What's new

* Introduced an "itf" suffix to invokestatic calls to preserve the fact that it is calling an interface method, which is required by the JVM verifier.

## What's fixed

* #454 
