### PR TITLE
Add tab press for indent code in SyntaxArea

### DIFF
--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/ManifestArea.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/ManifestArea.java
@@ -7,6 +7,7 @@ import me.coley.recaf.ui.CommonUX;
 import me.coley.recaf.ui.control.code.Languages;
 import me.coley.recaf.ui.control.code.ProblemTracking;
 import me.coley.recaf.ui.control.code.SyntaxArea;
+import me.coley.recaf.util.NodeEvents;
 import me.coley.recaf.util.StringUtil;
 import me.coley.recaf.util.logging.Logging;
 import me.coley.recaf.util.threading.FxThreadUtil;
@@ -39,7 +40,7 @@ public class ManifestArea extends SyntaxArea {
 	public ManifestArea(ProblemTracking problemTracking) {
 		super(Languages.MANIFEST, problemTracking);
 		// Register keybind / mouse action to open the main class when interacted with
-		setOnKeyPressed(e -> {
+		NodeEvents.addKeyPressHandler(this, e -> {
 			if (!StringUtil.isNullOrEmpty(mainClass) && Configs.keybinds().gotoDef.match(e)) {
 				rangeCheck(getCaretPosition());
 			}

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/code/SyntaxArea.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/code/SyntaxArea.java
@@ -745,7 +745,12 @@ public class SyntaxArea extends CodeArea implements BracketUpdateListener, Probl
 		int endCol = selection.getEndColumnPosition();
 		// selecting stating from the first column, to avoid adding \t in the middle of a word
 		selection.selectRange(startPar, 0, endPar, endCol);
-		replaceText(getSelectionStart(), getSelectionStop(), "\t" + getSelectionText().replace("\n", "\n\t"));
+		replaceText(getSelectionStart(), getSelectionStop(),
+			e.isShiftDown() ?
+				(getSelectionText().startsWith("\t") ? getSelectionText().substring(1 ) : getSelectionText())
+					.replace("\n\t", "\n") :
+				"\t" + getSelectionText().replace("\n", "\n\t")
+		);
 		// setting the selection anew, for further indentation
 		selection.selectRange(startPar, 0, endPar, endCol);
 	}

--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/code/java/JavaArea.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/code/java/JavaArea.java
@@ -32,6 +32,7 @@ import me.coley.recaf.ui.control.NavigationBar;
 import me.coley.recaf.ui.control.code.*;
 import me.coley.recaf.ui.util.Lang;
 import me.coley.recaf.util.JavaVersion;
+import me.coley.recaf.util.NodeEvents;
 import me.coley.recaf.util.logging.Logging;
 import me.coley.recaf.util.threading.FxThreadUtil;
 import me.coley.recaf.util.threading.ThreadUtil;
@@ -75,7 +76,7 @@ public class JavaArea extends SyntaxArea implements ClassRepresentation {
 			if (e.isMiddleButtonDown() || (e.isPrimaryButtonDown() && e.isControlDown()))
 				handleNavigation(e);
 		});
-		setOnKeyPressed(e -> {
+		NodeEvents.addKeyPressHandler(this, e -> {
 			int pos = getCaretPosition();
 			KeybindConfig config = Configs.keybinds();
 			if (config.gotoDef.match(e))


### PR DESCRIPTION
## What's new
![recaf](https://user-images.githubusercontent.com/50181314/187093162-cf60a6a9-5ab2-4362-87ce-c011caf8e0c3.gif)

https://github.com/Col-E/recaf-3x-issues/issues/102
It's this feature, but it adds only a `\t` before each line.