### PR TITLE
Fix assembler escaping issues

### DIFF
--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/BaseArg.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/BaseArg.java
@@ -3,7 +3,6 @@ package me.coley.recaf.assemble.ast;
 import me.coley.recaf.assemble.ast.arch.Annotation;
 import me.coley.recaf.util.EscapeUtil;
 import me.coley.recaf.util.OpcodeUtil;
-import me.coley.recaf.util.StringUtil;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Type;
 
@@ -121,11 +120,12 @@ public abstract class BaseArg extends BaseElement implements Printable {
 				return context.fmtKeyword("annotation-enum " ) + value;
 			case BOOLEAN:
 				return (Boolean) value ? "true" : "false";
+			case FLOAT:
+				return value + "F";
+			case LONG:
+				return value + "L";
 			case SHORT:
 			case INTEGER:
-			case FLOAT:
-			case DOUBLE:
-			case LONG:
 			default:
 				return String.valueOf(value);
 		}

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/HandleInfo.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/HandleInfo.java
@@ -89,6 +89,6 @@ public class HandleInfo extends BaseElement {
 
 	@Override
 	public String print(PrintContext context) {
-			return tag + " " + EscapeUtil.escapeSpace(owner + '.' + name) + ' ' + EscapeUtil.escapeSpace(desc);
+			return tag + " " + EscapeUtil.escapeNonValid(owner + '.' + name) + ' ' + EscapeUtil.escapeNonValid(desc);
 	}
 }

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/VariableReference.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/VariableReference.java
@@ -17,7 +17,7 @@ public interface VariableReference extends Element {
 	 * @return Whitespace escaped variable identifier.
 	 */
 	default String getEscapedVariableIdentifier() {
-		return EscapeUtil.escapeSpace(getVariableIdentifier());
+		return EscapeUtil.escapeNonValid(getVariableIdentifier());
 	}
 
 	/**
@@ -29,7 +29,7 @@ public interface VariableReference extends Element {
 	 * @return Whitespace escaped variable descriptor.
 	 */
 	default String getEscapedVariableDescriptor() {
-		return EscapeUtil.escapeSpace(getVariableDescriptor());
+		return EscapeUtil.escapeNonValid(getVariableDescriptor());
 	}
 
 	/**

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/arch/FieldDefinition.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/arch/FieldDefinition.java
@@ -32,7 +32,7 @@ public class FieldDefinition extends AbstractDefinition {
 		StringBuilder sb = new StringBuilder();
 		sb.append(super.buildDefString(context, context.fmtKeyword("field")));
 		// Make sure to escape the name
-		sb.append(EscapeUtil.escapeSpace(name)).append(' ').append(EscapeUtil.escape(type));
+		sb.append(EscapeUtil.escapeNonValid(name)).append(' ').append(EscapeUtil.escape(type));
 		// Print value if exists
 		if (getConstVal() != null) {
 			sb.append(" ").append(getConstVal().print(context));

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/arch/TryCatch.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/arch/TryCatch.java
@@ -76,6 +76,6 @@ public class TryCatch extends BaseElement implements CodeEntry {
 		if (type == null)
 			type = ANY_TYPE;
 		return String.format("%s %s %s %s %s", context.fmtKeyword("catch"),
-				EscapeUtil.escapeSpace(type), startLabel, endLabel, handlerLabel);
+				EscapeUtil.escapeNonValid(type), startLabel, endLabel, handlerLabel);
 	}
 }

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/FieldInstruction.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/FieldInstruction.java
@@ -59,8 +59,8 @@ public class FieldInstruction extends AbstractInstruction {
 	@Override
 	public String print(PrintContext context) {
 		return getOpcode() + " " +
-				EscapeUtil.escapeSpace(getOwner()) + '.' +
-				EscapeUtil.escapeSpace(getName()) + ' ' +
-				EscapeUtil.escapeSpace(getDesc());
+				EscapeUtil.escapeNonValid(getOwner()) + '.' +
+				EscapeUtil.escapeNonValid(getName()) + ' ' +
+				EscapeUtil.escapeNonValid(getDesc());
 	}
 }

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/IndyInstruction.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/IndyInstruction.java
@@ -85,11 +85,11 @@ public class IndyInstruction extends AbstractInstruction {
 		if (name.isEmpty()) {
 			name = "empty"; // TODO: Is this how we should handle empty BSM name?
 		} else {
-			name = EscapeUtil.escapeSpace(name);
+			name = EscapeUtil.escapeNonValid(name);
 		}
 		sb.append(getOpcode()).append(' ');
 		sb.append(name).append(' ');
-		sb.append(EscapeUtil.escapeSpace(desc)).append(' ');
+		sb.append(EscapeUtil.escapeNonValid(desc)).append(' ');
 		sb.append(context.fmtKeyword("handle ")).append(handle).append(' ');
 		sb.append(context.fmtKeyword("args ")).append(args).append(" ").append(context.fmtKeyword("end"));
 		return sb.toString();

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/MethodInstruction.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/MethodInstruction.java
@@ -74,13 +74,13 @@ public class MethodInstruction extends AbstractInstruction {
 		// we check for op != 'invokeinterface' because invokeinterface is always itf=true
 		if (isItf() && !this.getOpcode().equals("invokeinterface")) {
 			return getOpcode() + "interface " +
-					EscapeUtil.escapeSpace(getOwner()) + '.' +
-					EscapeUtil.escapeSpace(getName()) + ' ' +
-					EscapeUtil.escapeSpace(getDesc());
+					EscapeUtil.escapeNonValid(getOwner()) + '.' +
+					EscapeUtil.escapeNonValid(getName()) + ' ' +
+					EscapeUtil.escapeNonValid(getDesc());
 		}
 		return getOpcode() + " " +
-				EscapeUtil.escapeSpace(getOwner()) + '.' +
-				EscapeUtil.escapeSpace(getName()) + ' ' +
-				EscapeUtil.escapeSpace(getDesc());
+				EscapeUtil.escapeNonValid(getOwner()) + '.' +
+				EscapeUtil.escapeNonValid(getName()) + ' ' +
+				EscapeUtil.escapeNonValid(getDesc());
 	}
 }

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/MultiArrayInstruction.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/MultiArrayInstruction.java
@@ -1,6 +1,7 @@
 package me.coley.recaf.assemble.ast.insn;
 
 import me.coley.recaf.assemble.ast.PrintContext;
+import me.coley.recaf.util.EscapeUtil;
 
 /**
  * Multi array instruction.
@@ -46,6 +47,6 @@ public class MultiArrayInstruction extends AbstractInstruction {
 
 	@Override
 	public String print(PrintContext context) {
-		return getOpcode() + " " + getDesc() + " " + getDimensions();
+		return getOpcode() + " " + EscapeUtil.escapeNonValid(getDesc()) + " " + getDimensions();
 	}
 }

--- a/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/TypeInstruction.java
+++ b/recaf-assembler/src/main/java/me/coley/recaf/assemble/ast/insn/TypeInstruction.java
@@ -36,6 +36,6 @@ public class TypeInstruction extends AbstractInstruction {
 
 	@Override
 	public String print(PrintContext context) {
-		return String.format("%s %s", getOpcode(), EscapeUtil.escapeSpace(getType()));
+		return String.format("%s %s", getOpcode(), EscapeUtil.escapeNonValid(getType()));
 	}
 }

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/BasicClassPrintStrategy.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/BasicClassPrintStrategy.java
@@ -13,11 +13,9 @@ import me.coley.recaf.decompile.fallback.model.FieldModel;
 import me.coley.recaf.decompile.fallback.model.MethodModel;
 import me.coley.recaf.util.AccessFlag;
 import me.coley.recaf.util.EscapeUtil;
-import me.coley.recaf.util.StringUtil;
 import org.objectweb.asm.Type;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -67,7 +65,7 @@ public class BasicClassPrintStrategy implements ClassPrintStrategy, ConstantPool
 	private void appendPackage(Printer out, ClassModel model) {
 		String className = model.getName();
 		if (className.contains("/")) {
-			String packageName = EscapeUtil.escapeSpace(className.substring(0, className.lastIndexOf('/')));
+			String packageName = EscapeUtil.escapeNonValid(className.substring(0, className.lastIndexOf('/')));
 			out.appendLine("package " + packageName.replace('/', '.') + ";");
 			out.newLine();
 		}

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/BasicFieldPrintStrategy.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/BasicFieldPrintStrategy.java
@@ -41,7 +41,7 @@ public class BasicFieldPrintStrategy implements FieldPrintStrategy {
 
 	protected void appendTypeAndName(StringBuilder sb, FieldModel model) {
 		Type type = Type.getType(model.getDesc());
-		String typeName = EscapeUtil.escapeSpace(type.getClassName());
+		String typeName = EscapeUtil.escapeNonValid(type.getClassName());
 		if (typeName.contains("."))
 			typeName = typeName.substring(typeName.lastIndexOf(".") + 1);
 		sb.append(typeName).append(' ').append(PrintBase.filterName(model.getName()));

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/BasicMethodPrintStrategy.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/BasicMethodPrintStrategy.java
@@ -210,7 +210,7 @@ public class BasicMethodPrintStrategy implements MethodPrintStrategy {
 	 */
 	protected void buildDeclarationReturnType(StringBuilder sb, MethodModel model) {
 		Type methodType = Type.getMethodType(model.getDesc());
-		String returnTypeName = EscapeUtil.escapeSpace(methodType.getReturnType().getClassName());
+		String returnTypeName = EscapeUtil.escapeNonValid(methodType.getReturnType().getClassName());
 		if (returnTypeName.contains("."))
 			returnTypeName = returnTypeName.substring(returnTypeName.lastIndexOf(".") + 1);
 		sb.append(returnTypeName).append(' ');
@@ -256,7 +256,7 @@ public class BasicMethodPrintStrategy implements MethodPrintStrategy {
 		for (int param = 0; param < argTypes.length; param++) {
 			// Get arg type text
 			Type argType = argTypes[param];
-			String argTypeName = EscapeUtil.escapeSpace(argType.getClassName());
+			String argTypeName = EscapeUtil.escapeNonValid(argType.getClassName());
 			if (argTypeName.contains("."))
 				argTypeName = argTypeName.substring(argTypeName.lastIndexOf(".") + 1);
 			boolean isLast = param == argTypes.length - 1;

--- a/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/PrintBase.java
+++ b/recaf-core/src/main/java/me/coley/recaf/decompile/fallback/print/PrintBase.java
@@ -18,7 +18,7 @@ public interface PrintBase {
 	 * @return Filtered name.
 	 */
 	static String filterName(String name) {
-		return EscapeUtil.escapeSpace(name);
+		return EscapeUtil.escapeNonValid(name);
 	}
 
 	/**

--- a/recaf-utils/src/main/java/me/coley/recaf/util/EscapeUtil.java
+++ b/recaf-utils/src/main/java/me/coley/recaf/util/EscapeUtil.java
@@ -17,6 +17,8 @@ public final class EscapeUtil {
 	public static final String ESCAPED_TAB = "\\u0009";
 	public static final String ESCAPED_NEWLINE = "\\u000A";
 	public static final String ESCAPED_RETURN = "\\u000D";
+	public static final String ESCAPED_DOUBLE_QUOTE = "\\u0022";
+	public static final String ESCAPED_DOUBLE_SLASH = "\\u005C\\u005C";
 
 	private EscapeUtil() {
 	}
@@ -66,15 +68,15 @@ public final class EscapeUtil {
 	}
 
 	/**
-	 * Replaces any escapeable squence with the an escaped sequence, inclduing spaces.
+	 * Replaces any non JASM-compliant characters with an escaped sequence.
 	 *
 	 * @param input
 	 * 		Input text.
 	 *
 	 * @return String without escaped characters.
 	 */
-	public static String escapeSpace(String input) {
-		return visit(input, EscapeUtil::computeUnescapeUnicodeSpace);
+	public static String escapeNonValid(String input) {
+		return visit(input, EscapeUtil::computeUnescapeUnicodeNonValid);
 	}
 
 	/**
@@ -159,7 +161,7 @@ public final class EscapeUtil {
 		return 0;
 	}
 
-	private static int computeUnescapeUnicodeSpace(String input, int cursor, StringBuilder builder) {
+	private static int computeUnescapeUnicodeNonValid(String input, int cursor, StringBuilder builder) {
 		// Bounds check
 		if (cursor >= input.length()) {
 			return 0;
@@ -180,6 +182,12 @@ public final class EscapeUtil {
 				break;
 			case "\r":
 				escaped = ESCAPED_RETURN;
+				break;
+			case "\"" :
+				escaped = ESCAPED_DOUBLE_QUOTE;
+				break;
+			case "//" :
+				escaped = ESCAPED_DOUBLE_SLASH;
 				break;
 		}
 		if (escaped != null) {


### PR DESCRIPTION
## What's fixed
- `EscapeUtil` method name is now `escapeNonValid` instead of `escapeSpace`
- Escaping of parser tropes like: `"` or `//`
- Added escaping to some instructions who didn't have it
