### PR TITLE
Fix exception caused by mismatching types when setting default decompiler

### DIFF
--- a/recaf-ui/src/main/java/me/coley/recaf/ui/control/config/ConfigDecompiler.java
+++ b/recaf-ui/src/main/java/me/coley/recaf/ui/control/config/ConfigDecompiler.java
@@ -25,6 +25,6 @@ public class ConfigDecompiler extends DecompilerCombo implements Unlabeled {
 		select(initialDecompilerName);
 
 		getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) ->
-				ReflectUtil.quietSet(instance, field, newValue));
+				ReflectUtil.quietSet(instance, field, newValue.getName()));
 	}
 }


### PR DESCRIPTION
## What's fixed

* Fix IllegalArgumentException by setting decompiler field to decompiler name.