### PR TITLE
Optimize `filterGenerics()`

### DIFF
--- a/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
+++ b/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
@@ -125,7 +125,7 @@ public class JavaParserHelper {
 		String initial;
 		do{
 			initial = code;
-			Matcher matcher = RegexUtil.getMatcher("<[^<>+\\-*/%=&|!~^:]+>", code);
+			Matcher matcher = RegexUtil.getMatcher("<(\\s*)[?]?[^<>+\\-*/%=&|!~^:(){}?]*>", code);
 			while (matcher.find()) {
 				String temp = code.substring(0, matcher.start());
 				String filler = StringUtil.repeat(" ", matcher.length());

--- a/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
+++ b/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
@@ -17,6 +17,7 @@ import me.coley.recaf.parse.evaluation.ExpressionEvaluator;
 import me.coley.recaf.util.RegexUtil;
 import me.coley.recaf.util.StringUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -122,11 +123,16 @@ public class JavaParserHelper {
 	 */
 	private String filterGenerics(String code) {
 		// This isn't perfect, but should replace most basic generic type usage
-		Matcher matcher = RegexUtil.getMatcher("<[^<>]*>", code);
-		if (matcher.find()) {
-			code = code.replaceAll("<[^<>]*>", " ");
-			return filterGenerics(code);
-		}
+		String initial;
+		do{
+			initial = code;
+			Matcher matcher = RegexUtil.getMatcher("<[^<>+\\-*/%=&|!~^:]+>", code);
+			while (matcher.find()) {
+				String temp = code.substring(0, matcher.start());
+				String filler = StringUtil.repeat(" ", matcher.length());
+				code = temp + filler + code.substring(matcher.end());
+			}
+		} while (!initial.equals(code));
 		return code;
 	}
 

--- a/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
+++ b/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
@@ -122,11 +122,10 @@ public class JavaParserHelper {
 	 */
 	private String filterGenerics(String code) {
 		// This isn't perfect, but should replace most basic generic type usage
-		Matcher matcher = RegexUtil.getMatcher("(?:<)((?:(?!\\1).)*>)", code);
-		while (matcher.find()) {
-			String temp = code.substring(0, matcher.start());
-			String filler = StringUtil.repeat(" ", matcher.length());
-			code = temp + filler + code.substring(matcher.end());
+		Matcher matcher = RegexUtil.getMatcher("<[^<>]*>", code);
+		if (matcher.find()) {
+			code = code.replaceAll("<[^<>]*>", " ");
+			return filterGenerics(code);
 		}
 		return code;
 	}

--- a/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
+++ b/recaf-core/src/main/java/me/coley/recaf/parse/JavaParserHelper.java
@@ -17,7 +17,6 @@ import me.coley.recaf.parse.evaluation.ExpressionEvaluator;
 import me.coley.recaf.util.RegexUtil;
 import me.coley.recaf.util.StringUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 


### PR DESCRIPTION
## What's new



## What's fixed

For the optimization of code like the following, code processed by the old filterGenerics method will cause it to be damaged, causing JavaParser to not parse correctly.
```java
   static <T> Collection<T> a(Iterable<T> var0) {
      return (Collection<T>)var0;
   }

```

Then
```java
   static                                 var0) {
      return (Collection   )var0;
   }
```

Now
```java
   static  Collection  a(Iterable  var0) {
      return (Collection )var0;
   }
```