### PR TITLE
fix: Fixed misspelling of "parameters" in some instruction parsers

### DIFF
--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/AliasDeclarationParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/AliasDeclarationParser.java
@@ -15,7 +15,7 @@ public class AliasDeclarationParser extends AbstractParser<AliasAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/HandleParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/HandleParser.java
@@ -29,7 +29,7 @@ public class HandleParser extends AbstractParser<HandleAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			TagParser opParser = new TagParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/IincInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/IincInsnParser.java
@@ -18,7 +18,7 @@ public class IincInsnParser extends AbstractParser<IincInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 3)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/IntInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/IntInsnParser.java
@@ -18,7 +18,7 @@ public class IntInsnParser extends AbstractParser<IntInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/InvokeDynamicParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/InvokeDynamicParser.java
@@ -24,7 +24,7 @@ public class InvokeDynamicParser extends AbstractParser<InvokeDynamicAST> {
 			// INVOKEDYNAMIC name desc handle[...] args[...]
 			String[] trim = line.trim().split("\\s+(?=.*\\[(?=.*\\[))");
 			if (trim.length < 4)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			// 0 = op
 			// 1 = name
 			// 2 = desc

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/JumpInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/JumpInsnParser.java
@@ -18,7 +18,7 @@ public class JumpInsnParser extends AbstractParser<JumpInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/LineInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/LineInsnParser.java
@@ -18,7 +18,7 @@ public class LineInsnParser extends AbstractParser<LineInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 3)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/LookupSwitchInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/LookupSwitchInsnParser.java
@@ -27,7 +27,7 @@ public class LookupSwitchInsnParser extends AbstractParser<LookupSwitchInsnAST> 
 			// Collect parameters
 			String[] data = RegexUtil.allMatches(line, "(?<=\\[).*?(?=\\])");
 			if (data.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			// mapping
 			String mapS = data[0];
 			Map<NumberAST, NameAST> mapping = new LinkedHashMap<>();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/MethodInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/MethodInsnParser.java
@@ -20,7 +20,7 @@ public class MethodInsnParser extends AbstractParser<MethodInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/MultiArrayParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/MultiArrayParser.java
@@ -18,7 +18,7 @@ public class MultiArrayParser extends AbstractParser<MultiArrayInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/SignatureParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/SignatureParser.java
@@ -21,7 +21,7 @@ public class SignatureParser extends AbstractParser<SignatureAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			String sig = trim[1];
 			// TODO: Verify signature?
 			//  - Technically you can put in garbage data in here...

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/TableSwitchInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/TableSwitchInsnParser.java
@@ -27,7 +27,7 @@ public class TableSwitchInsnParser extends AbstractParser<TableSwitchInsnAST> {
 			// Collect parameters
 			String[] data = RegexUtil.allMatches(line, "(?<=\\[).*?(?=\\])");
 			if (data.length < 3)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			// min & max
 			String minMaxS = data[0];
 			if (!minMaxS.contains(":"))

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/TypeInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/TypeInsnParser.java
@@ -18,7 +18,7 @@ public class TypeInsnParser extends AbstractParser<TypeInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();

--- a/src/main/java/me/coley/recaf/parse/bytecode/parser/VarInsnParser.java
+++ b/src/main/java/me/coley/recaf/parse/bytecode/parser/VarInsnParser.java
@@ -18,7 +18,7 @@ public class VarInsnParser extends AbstractParser<VarInsnAST> {
 		try {
 			String[] trim = line.trim().split("\\s+");
 			if (trim.length < 2)
-				throw new ASTParseException(lineNo, "Not enough paramters");
+				throw new ASTParseException(lineNo, "Not enough parameters");
 			int start = line.indexOf(trim[0]);
 			// op
 			OpcodeParser opParser = new OpcodeParser();


### PR DESCRIPTION
## What's new

* Nada

## What's fixed

* A bunch of instruction parsers had the word "parameters" misspelled as "paramters" in an error except for one, which was already fixed 3 years ago.
