### PR TITLE
Fix jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+before_install:
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk install java 17.0.1-zulu
+  - sdk use java 17.0.1-zulu

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,3 @@
 before_install:
-  - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk update
   - sdk install java 17.0.1-zulu
   - sdk use java 17.0.1-zulu


### PR DESCRIPTION
## What's new

Nothing

## What's fixed

Jitpack
By default, jitpack uses java 8, this PR adds a `jitpack.yml` that tells it to use java 17
