### PR TITLE
#257 Warn before setting undo keybind to ctrl-z

### DIFF
--- a/src/main/java/me/coley/recaf/ui/controls/KeybindField.java
+++ b/src/main/java/me/coley/recaf/ui/controls/KeybindField.java
@@ -6,6 +6,7 @@ import javafx.scene.input.KeyCode;
 import me.coley.recaf.Recaf;
 import me.coley.recaf.config.ConfKeybinding;
 import me.coley.recaf.config.FieldWrapper;
+import me.coley.recaf.ui.controls.popup.YesNoWindow;
 import me.coley.recaf.util.LangUtil;
 import me.coley.recaf.util.Log;
 
@@ -55,13 +56,38 @@ public class KeybindField extends TextField {
 	}
 
 	private void update() {
-		conf().setIsUpdating(false);
-		target.clear();
-		target.addAll(lastest);
-		getParent().requestFocus();
 
-		setText(target.toString());
-		Log.info("Updating keybind '{}' to '{}'", name, target.toString());
+		// Warn a user if the undo hotkey is set to 'ctrl+z'
+		Log.debug(name + " -- "  + lastest.toString());
+		if(name.equals("Undo change") && lastest.toString().equals("ctrl+z")){
+			YesNoWindow.prompt(LangUtil.translate("binding.undo.warning.ctrl-z"), () -> {
+				// If the user pressed yes execute the change
+				target.clear();
+				target.addAll(lastest);
+				getParent().requestFocus();
+
+				setText(target.toString());
+				Log.info("Updating keybind '{}' to '{}'", name, target.toString());
+			}, () ->{
+				// If the user pressed no; log but don't change hotkey
+				getParent().requestFocus();
+				setText(target.toString());
+				Log.info("Keybind update canceled by user.");
+			}).show(getParent());
+
+			conf().setIsUpdating(false);
+		}
+		// If this change isn't adding control z proceed without prompt
+		else{
+			conf().setIsUpdating(false);
+			target.clear();
+			target.addAll(lastest);
+			getParent().requestFocus();
+
+			setText(target.toString());
+			Log.info("Updating keybind '{}' to '{}'", name, target.toString());
+		}
+
 	}
 
 	private ConfKeybinding conf() {

--- a/src/main/resources/translations/en.json
+++ b/src/main/resources/translations/en.json
@@ -511,6 +511,7 @@
 	"display.usesystemmenubar.desc": "Use system menubar on macOS.",
 
 	"binding": "Keybinds",
+	"binding.undo.warning.ctrl-z": "This is not the traditional text-editor undo. This will undo all recent changes. Are you sure you want to rebind?",
 	"binding.inputprompt.initial": " <waiting>",
 	"binding.inputprompt.finish": " <ENTER to finish>",
 	"binding.close.window.name": "Close window",


### PR DESCRIPTION
## Description
After looking at the issue #257 I added a check when changing keybinds that the keybind being set is undo and its being changed to ctrl-z a prompt will appear asking the user to confirm the change and explaining this isn't the standard text edit undo.

## Commit

feat: A confirmation prompt now appears when changing to undo keybind to ctrl-z

## What's new

* If the undo keybind is set to ctrl-z the user will be asked to confirm the decision by a pop up


