### PR TITLE
#580 Add new alternate rename hotkey so F2 can be mapped by default

### DIFF
--- a/src/main/java/me/coley/recaf/config/ConfKeybinding.java
+++ b/src/main/java/me/coley/recaf/config/ConfKeybinding.java
@@ -81,6 +81,14 @@ public class ConfKeybinding extends Config {
 			BindingCreator.OSBinding.from(OSUtil.MAC, Binding.from(KeyCode.META, KeyCode.R))
 	).buildKeyBindingForCurrentOS();
 	/**
+	 * Goto the selected item's definition.
+	 */
+	@Conf("binding.renameWFN")
+	public Binding renameWFN = BindingCreator.from(
+		Binding.from(KeyCode.F2),
+		BindingCreator.OSBinding.from(OSUtil.MAC, Binding.from(KeyCode.F2))
+	).buildKeyBindingForCurrentOS();
+	/**
 	 * Swap to the next view mode for the class viewport
 	 */
 	@Conf("binding.swapview")

--- a/src/main/java/me/coley/recaf/ui/controls/text/JavaEditorPane.java
+++ b/src/main/java/me/coley/recaf/ui/controls/text/JavaEditorPane.java
@@ -59,6 +59,11 @@ public class JavaEditorPane extends EditorPane<JavaErrorHandling, JavaContextHan
 				contextHandler.gotoSelectedDef();
 			else if(controller.config().keys().rename.match(e))
 				contextHandler.openRenameInput();
+			else if(controller.config().keys().renameWFN.match(e))
+				contextHandler.openRenameInput();
+
+
+
 		});
 	}
 

--- a/src/main/resources/translations/en.json
+++ b/src/main/resources/translations/en.json
@@ -527,6 +527,8 @@
 	"binding.find.desc": "Open find search menu.",
 	"binding.rename.name": "Rename",
 	"binding.rename.desc": "Rename the selected class/member.",
+	"binding.renameWFN.name": "Rename with Function",
+	"binding.renameWFN.desc": "Rename the selected class/member with a function (or any alternate) key.",
 	"binding.gotodef.name": "Goto definition",
 	"binding.gotodef.desc": "Jump to the definition of the selected item.",
 	"binding.swapview.name": "Swap view",


### PR DESCRIPTION
## Description
After reviewing issue #580 I saw that the current default rename hotkey (ctrl-r) can't be kept while mapping a function key (the issue suggests F2) to rename. I added a second hotkey for rename which allows for a function key (by default F2) to be mapped to rename.

## Commit
feat: Setup F2 as an alternate hotkey for rename

## What's new

* A second rename hotkey has been added which is set to F2 by default


