### PR TITLE
feat: detect lookup switch labels in search results

### DIFF
--- a/recaf-core/src/main/java/software/coley/recaf/services/search/query/AbstractValueQuery.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/search/query/AbstractValueQuery.java
@@ -225,6 +225,26 @@ public abstract class AbstractValueQuery implements JvmClassQuery, FileQuery {
 		}
 
 		@Override
+		public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
+			super.visitLookupSwitchInsn(dflt, keys, labels);
+			for (int key : keys) {
+				if (isMatch(key)) {
+					resultSink.accept(memberPath.childInsn(new InsnNode(Opcodes.LOOKUPSWITCH), index), key);
+				}
+			}
+		}
+
+		@Override
+		public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
+			super.visitTableSwitchInsn(min, max, dflt, labels);
+			for (int i = min; i <= max; i++) {
+				if (isMatch(i)) {
+					resultSink.accept(memberPath.childInsn(new InsnNode(Opcodes.TABLESWITCH), index), i);
+				}
+			}
+		}
+
+		@Override
 		public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
 			AnnotationVisitor av = super.visitAnnotation(desc, visible);
 			return new AnnotationValueVisitor(av, visible, resultSink,

--- a/recaf-core/src/main/java/software/coley/recaf/util/BlwUtil.java
+++ b/recaf-core/src/main/java/software/coley/recaf/util/BlwUtil.java
@@ -90,6 +90,8 @@ public class BlwUtil {
 				printer.execute(constWrapped);
 			else if (wrapped instanceof PrimitiveConversionInstruction convWrapped)
 				printer.execute(convWrapped);
+			else if (wrapped instanceof SimpleInstruction simpleWrapped)
+				printer.execute(simpleWrapped);
 			else
 				printer.execute(wrapped);
 		} else if (insn instanceof InvokeDynamicInsnNode indy) {


### PR DESCRIPTION
## What's new

Allow the search to match switch labels, and allow the result to be displayed in the result panel as 'lookupswitch'.

In my usecase, I have a huge codebase with a lot of 'switch' but I can't search for their  labels in Recaf 4.X (they are number):
![image](https://github.com/Col-E/Recaf/assets/48091696/361ba38c-edfc-43bc-b7f2-909d9e82b143)

Results:
![image](https://github.com/Col-E/Recaf/assets/48091696/3d8375f4-18ed-4936-a2d1-1bcb52fe744b)
Without the edit in BlwUtil, the instruction is passed to ``execute(Instruction instruction)` and thus nothing is displayed.
![image](https://github.com/Col-E/Recaf/assets/48091696/415755c7-da3d-454b-8399-9ca9f988fba8)
