### PR TITLE
Introducing Recaf Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Recaf [![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/Bya5HaA?style=flat)](https://discord.gg/Bya5HaA) [![codecov](https://codecov.io/gh/Col-E/Recaf/graph/badge.svg?token=N8GslpI1lL)](https://codecov.io/gh/Col-E/Recaf)  ![downloads](https://img.shields.io/github/downloads/Col-E/Recaf/total.svg) [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](CONTRIBUTING.md)
+# Recaf [![Discord](https://dcbadge.limes.pink/api/server/https://discord.gg/Bya5HaA?style=flat)](https://discord.gg/Bya5HaA) [![codecov](https://codecov.io/gh/Col-E/Recaf/graph/badge.svg?token=N8GslpI1lL)](https://codecov.io/gh/Col-E/Recaf)  ![downloads](https://img.shields.io/github/downloads/Col-E/Recaf/total.svg) [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](CONTRIBUTING.md) [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Recaf%20Guru-006BFF)](https://gurubase.io/g/recaf)
 
 ![Recaf 4x UI](recaf.png)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Recaf Guru](https://gurubase.io/g/recaf) to Gurubase. Recaf Guru uses the data from this repo and data from the [docs](https://recaf.coley.software/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Recaf Guru", which highlights that Recaf now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Recaf Guru in Gurubase, just let me know that's totally fine.
