### PR TITLE
Fix error in mapping generator

### DIFF
--- a/recaf-ui/src/main/java/software/coley/recaf/ui/pane/MappingGeneratorPane.java
+++ b/recaf-ui/src/main/java/software/coley/recaf/ui/pane/MappingGeneratorPane.java
@@ -789,7 +789,7 @@ public class MappingGeneratorPane extends StackPane {
 			grid.addRow(2, new BoundLabel(Lang.getBinding("mapgen.filter.method-name")),
 					txtMethod, new BoundComboBox<>(methodPredicateId, stringPredicatesWithNull, textPredicateConverter));
 			grid.addRow(3, new BoundLabel(Lang.getBinding("mapgen.filter.variable-name")),
-					txtMethod, new BoundComboBox<>(variablePredicateId, stringPredicatesWithNull, textPredicateConverter));
+					txtVariable, new BoundComboBox<>(variablePredicateId, stringPredicatesWithNull, textPredicateConverter));
 			sink.accept(null, grid);
 		}
 	}


### PR DESCRIPTION
## What's new

Nothing

## What's fixed

This error:
```
java.lang.IllegalArgumentException: Children: duplicate children added: parent = Grid hgap=5.0, vgap=5.0, alignment=TOP_LEFT
	at javafx.graphics@22.0.1/javafx.scene.Parent$3.onProposedChange(Parent.java:562)
	at javafx.base@22.0.1/com.sun.javafx.collections.VetoableListDecorator.addAll(VetoableListDecorator.java:238)
	at javafx.base@22.0.1/com.sun.javafx.collections.VetoableListDecorator.addAll(VetoableListDecorator.java:105)
	at javafx.graphics@22.0.1/javafx.scene.layout.GridPane.addRow(GridPane.java:1032)
	at software.coley.recaf.ui.pane.MappingGeneratorPane$IncludeName.fillConfigurator(MappingGeneratorPane.java:791)
	at software.coley.recaf.ui.pane.MappingGeneratorPane$FilterWithConfigNode.getConfigurator(MappingGeneratorPane.java:1006)
	at software.coley.recaf.ui.pane.MappingGeneratorPane.showConfigurator(MappingGeneratorPane.java:436)
	at software.coley.recaf.ui.pane.MappingGeneratorPane.lambda$createFilterDisplay$10(MappingGeneratorPane.java:367)
	at software.coley.recaf.ui.control.ActionButton.wrap(ActionButton.java:147)
	at software.coley.recaf.ui.control.ActionButton.lambda$new$2(ActionButton.java:67)
```
It occurs when you try to add an "Include names" filter in the mapping generator
