### PR TITLE
Fix the LinearOpaqueConstantFoldingTransformer

### DIFF
--- a/recaf-core/src/main/java/software/coley/recaf/services/deobfuscation/transform/generic/NopRemovingTransformer.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/deobfuscation/transform/generic/NopRemovingTransformer.java
@@ -1,0 +1,57 @@
+package software.coley.recaf.services.deobfuscation.transform.generic;
+
+import jakarta.annotation.Nonnull;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.MethodNode;
+import software.coley.recaf.info.JvmClassInfo;
+import software.coley.recaf.services.transform.JvmClassTransformer;
+import software.coley.recaf.services.transform.JvmTransformerContext;
+import software.coley.recaf.services.transform.TransformationException;
+import software.coley.recaf.workspace.model.Workspace;
+import software.coley.recaf.workspace.model.bundle.JvmClassBundle;
+import software.coley.recaf.workspace.model.resource.WorkspaceResource;
+
+import static org.objectweb.asm.Opcodes.NOP;
+
+/**
+ * A transformer that clean the nop instructions from methods.
+ *
+ * @author Canrad
+ */
+public class NopRemovingTransformer implements JvmClassTransformer {
+
+    public NopRemovingTransformer() {
+
+    }
+
+    @Override
+    public void transform(@Nonnull JvmTransformerContext context, @Nonnull Workspace workspace,
+                          @Nonnull WorkspaceResource resource, @Nonnull JvmClassBundle bundle,
+                          @Nonnull JvmClassInfo initialClassState) throws TransformationException {
+
+        boolean dirty = false;
+        ClassNode node = context.getNode(bundle, initialClassState);
+        for (MethodNode method : node.methods) {
+            InsnList instructions = method.instructions;
+            if (instructions == null)
+                continue;
+            for (AbstractInsnNode insn : method.instructions.toArray()) {
+                if (insn.getOpcode() == NOP) {
+                    dirty = true;
+                    method.instructions.remove(insn);
+                }
+            }
+        }
+        if (dirty){
+            context.setNode(bundle, initialClassState, node);
+        }
+    }
+
+    @Nonnull
+    @Override
+    public String name() {
+        return "nop removal";
+    }
+}

--- a/recaf-ui/src/main/java/software/coley/recaf/ui/window/DeobfuscationWindow.java
+++ b/recaf-ui/src/main/java/software/coley/recaf/ui/window/DeobfuscationWindow.java
@@ -42,24 +42,7 @@ import software.coley.recaf.services.assembler.AssemblerPipelineManager;
 import software.coley.recaf.services.assembler.JvmAssemblerPipeline;
 import software.coley.recaf.services.cell.CellConfigurationService;
 import software.coley.recaf.services.decompile.DecompilerManager;
-import software.coley.recaf.services.deobfuscation.transform.generic.CycleClassRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.DeadCodeRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.DuplicateAnnotationRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.DuplicateCatchMergingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.EnumNameRestorationTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.GotoInliningTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.IllegalAnnotationRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.IllegalSignatureRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.IllegalVarargsRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.KotlinNameRestorationTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.LinearOpaqueConstantFoldingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.LongAnnotationRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.OpaquePredicateFoldingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.RedundantTryCatchRemovingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.SourceNameRestorationTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.StackOperationFoldingTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.StaticValueInliningTransformer;
-import software.coley.recaf.services.deobfuscation.transform.generic.VariableFoldingTransformer;
+import software.coley.recaf.services.deobfuscation.transform.generic.*;
 import software.coley.recaf.services.info.association.FileTypeSyntaxAssociationService;
 import software.coley.recaf.services.navigation.Actions;
 import software.coley.recaf.services.transform.ClassTransformer;
@@ -150,6 +133,7 @@ public class DeobfuscationWindow extends RecafStage {
 					DuplicateCatchMergingTransformer.class,
 					GotoInliningTransformer.class,
 					LinearOpaqueConstantFoldingTransformer.class,
+					NopRemovingTransformer.class,
 					OpaquePredicateFoldingTransformer.class,
 					RedundantTryCatchRemovingTransformer.class,
 					StackOperationFoldingTransformer.class,


### PR DESCRIPTION
## What's new

* Splitting the NopRemovingTransformer out from the LinearOpaqueConstantFoldingTransformer

In this way, the NopRemovingTransformer can be reused or used alone. And we can more easily LinearOpaqueConstantFoldingTransformer exactly do what

## What's fixed

* Fix the LinearOpaqueConstantFoldingTransformer can not handle the dup2 situation.
