### PR TITLE
Support preserving original package when remapping illegal names

### DIFF
--- a/recaf-core/src/main/java/software/coley/recaf/services/deobfuscation/transform/generic/IllegalNameMappingTransformer.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/deobfuscation/transform/generic/IllegalNameMappingTransformer.java
@@ -40,17 +40,17 @@ public class IllegalNameMappingTransformer implements JvmClassTransformer {
 		IntermediateMappings mappings = context.getMappings();
 		String ownerName = initialClassState.getName();
 		if (ILLEGAL_NAME_FILTER.shouldMapClass(initialClassState) && mappings.getMappedClassName(ownerName) == null)
-			mappings.addClass(ownerName, NAME_GENERATOR.mapClass(initialClassState));
+			mappings.addClass(ownerName, NAME_GENERATOR.mapClass(initialClassState, ILLEGAL_NAME_FILTER.shouldMapPackage(initialClassState)));
 		for (FieldMember field : initialClassState.getFields()) {
 			String fieldDesc = field.getDescriptor();
 			String fieldName = field.getName();
-			if (ILLEGAL_NAME_FILTER.shouldMapField(initialClassState, field) && mappings.getMappedFieldName(ownerName, fieldDesc, fieldName) == null)
+			if (ILLEGAL_NAME_FILTER.shouldMapField(initialClassState, field) && mappings.getMappedFieldName(ownerName, fieldName, fieldDesc) == null)
 				mappings.addField(ownerName, fieldDesc, field.getName(), NAME_GENERATOR.mapField(initialClassState, field));
 		}
 		for (MethodMember method : initialClassState.getMethods()) {
 			String methodDesc = method.getDescriptor();
 			String methodName = method.getName();
-			if (ILLEGAL_NAME_FILTER.shouldMapMethod(initialClassState, method) && mappings.getMappedMethodName(ownerName, methodDesc, methodName) == null)
+			if (ILLEGAL_NAME_FILTER.shouldMapMethod(initialClassState, method) && mappings.getMappedMethodName(ownerName, methodName, methodDesc) == null)
 				mappings.addMethod(ownerName, methodDesc, method.getName(), NAME_GENERATOR.mapMethod(initialClassState, method));
 		}
 	}

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/MappingGenerator.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/MappingGenerator.java
@@ -260,7 +260,7 @@ public class MappingGenerator implements Service {
 
 			// Add mapping.
 			String name = vertex.getName();
-			String mapped = generator.mapClass(classInfo);
+			String mapped = generator.mapClass(classInfo, filter.shouldMapPackage(classInfo));
 			mappings.addClass(name, mapped);
 		});
 	}

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeClassesFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeClassesFilter.java
@@ -35,6 +35,11 @@ public class IncludeClassesFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		return shouldMapClass(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember field) {
 		// Consider owner type, we do not want to map fields if they are outside the inclusion filter
 		return shouldMapClass(owner) && super.shouldMapField(owner, field);

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeKeywordNameFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeKeywordNameFilter.java
@@ -38,6 +38,14 @@ public class IncludeKeywordNameFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		String packageName = info.getPackageName();
+		if (packageName != null && containsKeyword(packageName))
+			return true;
+		return super.shouldMapPackage(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember info) {
 		if (containsKeyword(info.getName()))
 			return true;

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeLongNameFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeLongNameFilter.java
@@ -52,6 +52,14 @@ public class IncludeLongNameFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		String packageName = info.getPackageName();
+		if (targetClasses && packageName != null && shouldMap(packageName))
+			return true;
+		return super.shouldMapPackage(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember field) {
 		if (targetFields && shouldMap(field))
 			return true;

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeModifiersNameFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeModifiersNameFilter.java
@@ -50,6 +50,11 @@ public class IncludeModifiersNameFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		return shouldMapClass(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember field) {
 		if (targetFields && field.hasAnyModifiers(flags))
 			return true;

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeNameFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeNameFilter.java
@@ -54,6 +54,11 @@ public class IncludeNameFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		return shouldMapClass(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember field) {
 		if (fieldPredicate != null && fieldPredicate.match(field.getName()))
 			return true;

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeNonAsciiNameFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeNonAsciiNameFilter.java
@@ -30,6 +30,14 @@ public class IncludeNonAsciiNameFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		String packageName = info.getPackageName();
+		if (packageName != null && shouldMap(packageName))
+			return true;
+		return super.shouldMapPackage(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember field) {
 		if (shouldMap(field))
 			return true;

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeNonJavaIdentifierNameFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeNonJavaIdentifierNameFilter.java
@@ -43,6 +43,14 @@ public class IncludeNonJavaIdentifierNameFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		String packageName = info.getPackageName();
+		if (packageName != null && isInvalidName(packageName))
+			return true;
+		return super.shouldMapPackage(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember info) {
 		if (isInvalidName(info.getName()))
 			return true;

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeWhitespaceNameFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/IncludeWhitespaceNameFilter.java
@@ -31,6 +31,14 @@ public class IncludeWhitespaceNameFilter extends NameGeneratorFilter {
 	}
 
 	@Override
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		String packageName = info.getPackageName();
+		if (packageName != null && shouldMap(packageName))
+			return true;
+		return super.shouldMapPackage(info);
+	}
+
+	@Override
 	public boolean shouldMapField(@Nonnull ClassInfo owner, @Nonnull FieldMember field) {
 		if (shouldMap(field))
 			return true;

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/NameGeneratorFilter.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/filter/NameGeneratorFilter.java
@@ -50,6 +50,17 @@ public abstract class NameGeneratorFilter {
 	}
 
 	/**
+	 * @param info Class whose package should be checked.
+	 * @return {@code true} when a remapped class should also be moved to a different package.
+	 */
+	public boolean shouldMapPackage(@Nonnull ClassInfo info) {
+		if (defaultMap)
+			return next == null || next.shouldMapPackage(info);
+		else
+			return next != null && next.shouldMapPackage(info);
+	}
+
+	/**
 	 * @param owner
 	 * 		Class the field is defined in.
 	 * @param field

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/naming/AlphabetNameGenerator.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/naming/AlphabetNameGenerator.java
@@ -33,11 +33,19 @@ public class AlphabetNameGenerator implements DeconflictingNameGenerator {
 
 	@Nonnull
 	private String name(@Nullable String original) {
+		return name(original, null);
+	}
+
+	@Nonnull
+	private String name(@Nullable String original, @Nullable String packageName) {
 		int seed = original == null ? alphabet.hashCode() : original.hashCode();
-		String name = StringUtil.generateName(alphabet, length, seed);
+		String simpleName = StringUtil.generateName(alphabet, length, seed);
+		String name = packageName == null ? simpleName : packageName + "/" + simpleName;
 		if (workspace != null) {
 			while (workspace.findClass(name) != null)
-				name = StringUtil.generateName(alphabet, length, seed++);
+				name = packageName == null ?
+						StringUtil.generateName(alphabet, length, ++seed) :
+						packageName + "/" + StringUtil.generateName(alphabet, length, ++seed);
 		}
 		return name;
 	}
@@ -50,11 +58,21 @@ public class AlphabetNameGenerator implements DeconflictingNameGenerator {
 	@Nonnull
 	@Override
 	public String mapClass(@Nonnull ClassInfo info) {
+		return mapClass(info, true);
+	}
+
+	@Nonnull
+	@Override
+	public String mapClass(@Nonnull ClassInfo info, boolean mapPackage) {
 		if (info.isInDefaultPackage())
 			return name(info.getName());
 
-		// Ensure classes in the same package are kept together
-		return name(info.getPackageName()) + "/" + name(info.getName());
+		if (!mapPackage)
+			return name(info.getName(), info.getPackageName());
+
+		// Ensure classes in the same package are kept together.
+		String mappedPackage = name(info.getPackageName());
+		return name(info.getName(), mappedPackage);
 	}
 
 	@Nonnull

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/naming/IncrementingNameGenerator.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/naming/IncrementingNameGenerator.java
@@ -22,8 +22,11 @@ public class IncrementingNameGenerator implements DeconflictingNameGenerator {
 	private long varIndex = 1;
 
 	@Nonnull
-	private String nextClassName() {
-		return "mapped/Class" + classIndex++;
+	private String nextClassName(@Nullable String packageName) {
+		String simpleName = "Class" + classIndex++;
+		if (packageName == null || packageName.isEmpty())
+			return simpleName;
+		return packageName + "/" + simpleName;
 	}
 
 	@Nonnull
@@ -49,10 +52,17 @@ public class IncrementingNameGenerator implements DeconflictingNameGenerator {
 	@Nonnull
 	@Override
 	public String mapClass(@Nonnull ClassInfo info) {
-		String name = nextClassName();
+		return mapClass(info, true);
+	}
+
+	@Nonnull
+	@Override
+	public String mapClass(@Nonnull ClassInfo info, boolean mapPackage) {
+		String packageName = mapPackage ? "mapped" : info.getPackageName();
+		String name = nextClassName(packageName);
 		if (workspace != null) {
 			while (workspace.findClass(name) != null)
-				name = nextClassName();
+				name = nextClassName(packageName);
 		}
 		return name;
 	}

--- a/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/naming/NameGenerator.java
+++ b/recaf-core/src/main/java/software/coley/recaf/services/mapping/gen/naming/NameGenerator.java
@@ -22,6 +22,27 @@ public interface NameGenerator {
 	String mapClass(@Nonnull ClassInfo info);
 
 	/**
+	 * @param info
+	 * 		Class to rename.
+	 * @param mapPackage
+	 * 		{@code true} to allow remapping the package path.
+	 *        {@code false} to keep the class in its current package.
+	 *
+	 * @return New class name.
+	 */
+	@Nonnull
+	default String mapClass(@Nonnull ClassInfo info, boolean mapPackage) {
+		String mappedName = mapClass(info);
+		if (mapPackage || info.isInDefaultPackage())
+			return mappedName;
+
+		String packageName = info.getPackageName();
+		int separatorIndex = mappedName.lastIndexOf('/');
+		String simpleName = separatorIndex >= 0 ? mappedName.substring(separatorIndex + 1) : mappedName;
+		return packageName + "/" + simpleName;
+	}
+
+	/**
 	 * @param owner
 	 * 		Class the field is defined in.
 	 * @param field

--- a/recaf-core/src/test/java/software/coley/recaf/services/mapping/gen/MappingGeneratorTest.java
+++ b/recaf-core/src/test/java/software/coley/recaf/services/mapping/gen/MappingGeneratorTest.java
@@ -32,6 +32,8 @@ import software.coley.recaf.services.mapping.gen.filter.IncludeNonAsciiNameFilte
 import software.coley.recaf.services.mapping.gen.filter.IncludeNonJavaIdentifierNameFilter;
 import software.coley.recaf.services.mapping.gen.filter.IncludeWhitespaceNameFilter;
 import software.coley.recaf.services.mapping.gen.filter.NameGeneratorFilter;
+import software.coley.recaf.services.mapping.gen.naming.AlphabetNameGenerator;
+import software.coley.recaf.services.mapping.gen.naming.IncrementingNameGenerator;
 import software.coley.recaf.services.mapping.gen.naming.NameGenerator;
 import software.coley.recaf.services.search.match.StringPredicate;
 import software.coley.recaf.services.search.match.StringPredicateProvider;
@@ -444,6 +446,10 @@ public class MappingGeneratorTest extends TestBase {
 			// Edge case: 'package-info' and 'module-info' are not keywords, but they contain the keyword 'package' and 'module' respectively.
 			assertFalse(filter.shouldMapClass(new StubClassInfo("package-info")));
 			assertFalse(filter.shouldMapClass(new StubClassInfo("module-info")));
+
+			// Only remap the package when the package path itself is the problem.
+			assertFalse(filter.shouldMapPackage(new StubClassInfo("com/example/class")));
+			assertTrue(filter.shouldMapPackage(new StubClassInfo("com/class/Example")));
 		}
 
 		@Test
@@ -458,6 +464,8 @@ public class MappingGeneratorTest extends TestBase {
 				assertTrue(filter.shouldMapClass(new StubClassInfo("com/_/Example".replace("_", space))));
 				assertTrue(filter.shouldMapClass(new StubClassInfo("_/example/Example".replace("_", space))));
 				assertTrue(filter.shouldMapClass(new StubClassInfo("_".replace("_", space))));
+				assertFalse(filter.shouldMapPackage(new StubClassInfo("com/example/Bad_".replace("_", space))));
+				assertTrue(filter.shouldMapPackage(new StubClassInfo("com/_/Example".replace("_", space))));
 			}
 		}
 
@@ -477,6 +485,10 @@ public class MappingGeneratorTest extends TestBase {
 
 			// Technically in the ASCII set, but still non-ASCII in the sense of Java identifiers, should be mapped.
 			assertTrue(filter.shouldMapClass(new StubClassInfo("\0")));
+
+			// Only remap the package when the package path itself is the problem.
+			assertFalse(filter.shouldMapPackage(new StubClassInfo("com/example/Exämple")));
+			assertTrue(filter.shouldMapPackage(new StubClassInfo("cöm/example/Example")));
 		}
 
 		@Test
@@ -497,11 +509,38 @@ public class MappingGeneratorTest extends TestBase {
 			// A package part that starts with a number is not valid, should be mapped.
 			assertTrue(filter.shouldMapClass(new StubClassInfo("com/1A/Example")));
 			assertFalse(filter.shouldMapClass(new StubClassInfo("com/A1/Example")));
+			assertFalse(filter.shouldMapPackage(new StubClassInfo("com/example/1Example")));
+			assertTrue(filter.shouldMapPackage(new StubClassInfo("com/1A/Example")));
 
 			// Edge case: 'package-info' and 'module-info' are not valid Java identifiers, but they are exempt
 			// from this filter since they have special meaning in Java.
 			assertFalse(filter.shouldMapClass(new StubClassInfo("package-info")));
 			assertFalse(filter.shouldMapClass(new StubClassInfo("module-info")));
+		}
+
+		@Test
+		void testIncrementingGeneratorPreservesLegalPackageForIllegalClassName() {
+			IncludeNonJavaIdentifierNameFilter filter = new IncludeNonJavaIdentifierNameFilter(null);
+			ClassInfo info = new StubClassInfo("pack/pack/1");
+			IncrementingNameGenerator generator = new IncrementingNameGenerator();
+
+			assertTrue(filter.shouldMapClass(info));
+			assertFalse(filter.shouldMapPackage(info));
+			assertEquals("pack/pack/Class1", generator.mapClass(info, filter.shouldMapPackage(info)));
+		}
+
+		@Test
+		void testAlphabetGeneratorPreservesLegalPackageForIllegalClassName() {
+			IncludeNonJavaIdentifierNameFilter filter = new IncludeNonJavaIdentifierNameFilter(null);
+			ClassInfo info = new StubClassInfo("pack/pack/1");
+			AlphabetNameGenerator generator = new AlphabetNameGenerator("abcdefghijklmnopqrstuvwxyz", 3);
+
+			assertTrue(filter.shouldMapClass(info));
+			assertFalse(filter.shouldMapPackage(info));
+
+			String mapped = generator.mapClass(info, filter.shouldMapPackage(info));
+			assertTrue(mapped.startsWith("pack/pack/"));
+			assertNotEquals(info.getName(), mapped);
 		}
 
 		@Test


### PR DESCRIPTION
- Add `mapClass(info, mapPackage)` to `NameGenerator` to control package remapping.
- Implement package-aware naming in `AlphabetNameGenerator` and `IncrementingNameGenerator`.
- Introduce `shouldMapPackage` in `NameGeneratorFilter` and all filter implementations to decide whether a class's package should be remapped.
- Update `MappingGenerator` and `IllegalNameMappingTransformer` to use the new package mapping logic.
- Fix argument order in `getMappedFieldName`/`getMappedMethodName` calls within `IllegalNameMappingTransformer`.
- Add tests verifying that illegal class names are remapped while keeping legal packages intact.

## What's new

* I don't know.

## What's fixed

* I don't know.